### PR TITLE
Remove serviceWorker for local environment

### DIFF
--- a/index.html
+++ b/index.html
@@ -523,7 +523,11 @@
     <script src="script.js"></script>
     <script>
         // Register Service Worker for PWA functionality
-        if ('serviceWorker' in navigator) {
+        if (
+            'serviceWorker' in navigator &&
+            location.hostname !== 'localhost' &&
+            location.hostname !== '127.0.0.1'
+        ) {
             window.addEventListener('load', () => {
                 navigator.serviceWorker.register('/sw.js')
                     .then(registration => {


### PR DESCRIPTION
## ✨ Description

Le service worker crée du cache en local et fait que le live server ne fonctionne pas bien.

Le but est de le supprimer pour un développement en local. 

Fixes #: #47 