### PR TITLE
Add Image Compressor/Optimizer Tool.

### DIFF
--- a/index.html
+++ b/index.html
@@ -652,6 +652,25 @@
                     </div>
                 </a>
 
+                <!-- Image Compressor -->
+                <a href="tools/image-compressor/index.html" class="tool-card" data-category="utility">
+                    <div class="tool-icon">
+                        <i class="fas fa-compress"></i>
+                    </div>
+                    <div class="tool-content">
+                        <h3 class="tool-title">Image Compressor</h3>
+                        <p class="tool-description">Upload a JPG/PNG, adjust quality and optionally resize, then compress in-browser and download.</p>
+                        <div class="tool-tags">
+                            <span class="tag">Image</span>
+                            <span class="tag">Compression</span>
+                            <span class="tag">Utility</span>
+                        </div>
+                    </div>
+                    <div class="tool-arrow">
+                        <i class="fas fa-arrow-right"></i>
+                    </div>
+                </a>
+
                 <!-- URL Encoder/Decoder -->
                 <a href="tools/url-encoder-decoder/index.html" class="tool-card" data-category="utility">
                     <div class="tool-icon">

--- a/tools/image-compressor/index.html
+++ b/tools/image-compressor/index.html
@@ -90,11 +90,40 @@
     .label { color: var(--text-primary); font-size: 0.9rem; opacity: 0.9; }
     .stat { font-size: 0.85rem; color: var(--text-secondary); }
 
+    .checkbox-wrapper { position: relative; display: inline-flex; align-items: center; gap: 8px; }
+    .checkbox-wrapper input[type="checkbox"] {
+      appearance: none;
+      width: 20px;
+      height: 20px;
+      border: 2px solid var(--primary-color);
+      border-radius: 4px;
+      background: transparent;
+      cursor: pointer;
+      position: relative;
+      transition: all 0.3s ease;
+    }
+    .checkbox-wrapper input[type="checkbox"]:checked {
+      background: var(--primary-color);
+      border-color: var(--primary-color);
+    }
+    .checkbox-wrapper input[type="checkbox"]:checked::after {
+      content: '✓';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      color: #fff;
+      font-size: 12px;
+      font-weight: bold;
+    }
+
     .preview-wrap { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
     .preview { background: var(--bg-tertiary); border: 1px dashed rgba(255,255,255,0.2); border-radius: var(--radius-lg); min-height: 220px; display: flex; align-items: center; justify-content: center; overflow: auto; position: relative; }
+    .preview.uploader { cursor: pointer; }
+    .preview.uploader.dragover { border-color: var(--primary-color); background: rgba(255,107,53,0.06); }
     .preview .resizable { resize: both; overflow: auto; display: inline-block; }
     .preview img, .preview canvas { width: 100%; height: 100%; display: block; object-fit: contain; }
-    .badge { position: absolute; top: 8px; left: 8px; background: rgba(255,255,255,0.06); padding: 4px 8px; border-radius: 999px; font-size: 12px; color: var(--text-primary); border: 1px solid rgba(255,255,255,0.12); }
+    .badge { position: absolute; top: 8px; left: 8px; background: rgb(67 78 92); padding: 4px 8px; border-radius: 999px; font-size: 12px; color: var(--text-primary); border: 1px solid rgba(255,255,255,0.12); }
 
     .actions { display: flex; gap: 10px; }
     .btn { display: inline-flex; align-items: center; gap: 8px; padding: 10px 14px; border-radius: var(--radius-md); background: var(--primary-color); color: #fff; border: 1px solid transparent; cursor: pointer; font-weight: 600; transition: all .2s ease; }
@@ -134,15 +163,13 @@
       <h1 class="tool-title">Image Compressor</h1>
       <p class="tool-subtitle">Compress JPG/PNG images in your browser. Adjust quality, optionally resize, and download instantly. All processing happens locally.</p>
     </div>
-
+    <div>
+        <label class="label hidden" for="fileInput">Select image (JPG or PNG)</label>
+        <input id="fileInput" type="file" accept="image/jpeg,image/png" class="hidden" />
+    </div>
     <main>
       <section class="panel">
         <div class="row">
-          <div>
-            <label class="label" for="fileInput">Select image (JPG or PNG)</label>
-            <input id="fileInput" type="file" accept="image/jpeg,image/png" />
-            <div class="note">We process images entirely in your browser. No upload to a server.</div>
-          </div>
           <div class="controls">
             <div class="slider-row">
               <span class="label">Quality</span>
@@ -166,9 +193,9 @@
                 <label class="label" for="maxHeight">Max height (px)</label>
                 <input id="maxHeight" type="number" min="1" placeholder="e.g., 1080 (optional)" />
               </div>
-              <div style="display:flex; align-items:center; gap:8px;">
+              <div class="checkbox-wrapper">
                 <input id="keepAspect" type="checkbox" checked />
-                <label class="label" for="keepAspect" style="margin:0;">Keep aspect ratio</label>
+                <label class="label" for="keepAspect" style="margin:0; cursor:pointer;">Keep aspect ratio</label>
               </div>
             </div>
           </div>
@@ -176,9 +203,9 @@
       </section>
 
       <section class="panel preview-wrap">
-        <div class="preview" id="origPreview">
+        <div class="preview uploader" id="origPreview" role="button" tabindex="0" aria-label="Upload image by clicking or dropping here">
           <span class="badge">Original</span>
-          <span class="note">No image selected</span>
+          <span class="note">Click or drop an image here</span>
         </div>
         <div class="preview" id="compPreview">
           <span class="badge">Compressed</span>

--- a/tools/image-compressor/index.html
+++ b/tools/image-compressor/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image Compressor - DevToolkit</title>
+  <link rel="stylesheet" href="../../style.css" />
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    /* Tool-specific styles aligned with template */
+    .tool-container { max-width: 1100px; margin: 0 auto; padding: 2rem; }
+    .tool-header { text-align: center; margin-bottom: 2rem; }
+    .tool-title {
+      font-size: clamp(2rem, 4vw, 3rem);
+      font-weight: 700;
+      background: var(--gradient-primary);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      margin-bottom: 0.75rem;
+    }
+    .tool-subtitle { font-size: 1.1rem; color: var(--text-secondary); max-width: 700px; margin: 0.5rem auto 0; }
+
+    .back-button { position: fixed; top: 2rem; left: 2rem; z-index: 1000; display: flex; align-items: center; gap: 0.5rem; padding: 0.75rem 1.5rem; background: var(--bg-secondary); color: var(--text-primary); text-decoration: none; border-radius: var(--radius-md); border: 1px solid rgba(255, 255, 255, 0.1); transition: all 0.3s ease; backdrop-filter: blur(20px); }
+    .back-button:hover { background: var(--primary-color); color: #fff; transform: translateY(-2px); box-shadow: var(--shadow-lg); }
+
+    .panel { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: 1.25rem; margin-bottom: 1rem; position: relative; overflow: hidden; }
+    .panel::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--gradient-primary); }
+
+    .row { display: flex; gap: 1rem; flex-wrap: wrap; align-items: center; }
+    .row.end { align-items: flex-end; }
+    .row > * { flex: 1; }
+    .row.tight { gap: 0.75rem; }
+    .flex2 { flex: 2; }
+    .controls { display: grid; grid-template-columns: 1fr; gap: 0.75rem; }
+    .slider-row { display: grid; grid-template-columns: 90px 1fr 70px; gap: 0.6rem; align-items: center; }
+
+    /* Consistent input and dropdown styling */
+    select,
+    input[type="file"],
+    input[type="number"] {
+      padding: 0.65rem 0.9rem;
+      background: var(--bg-primary);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: var(--radius-md);
+      color: var(--text-primary);
+      font-size: 0.95rem;
+    }
+    select { cursor: pointer; }
+    select:focus,
+    input[type="file"]:focus,
+    input[type="number"]:focus {
+      outline: none;
+      border-color: var(--primary-color);
+      box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.15);
+    }
+
+    /* Range slider styling */
+    input[type="range"] {
+      width: 100%;
+      -webkit-appearance: none;
+      appearance: none;
+      height: 4px;
+      background: rgba(255, 255, 255, 0.2);
+      border-radius: 999px;
+      outline: none;
+    }
+    input[type="range"]::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 18px; height: 18px;
+      border-radius: 50%;
+      background: var(--primary-color);
+      border: 2px solid rgba(255,255,255,0.6);
+      box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+      cursor: pointer;
+      margin-top: -7px;
+    }
+    input[type="range"]::-moz-range-thumb {
+      width: 18px; height: 18px;
+      border-radius: 50%;
+      background: var(--primary-color);
+      border: 2px solid rgba(255,255,255,0.6);
+      box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+      cursor: pointer;
+    }
+    .readonly-value { width: 70px; background: transparent; border: none; color: var(--text-primary); text-align: right; }
+
+    .label { color: var(--text-primary); font-size: 0.9rem; opacity: 0.9; }
+    .stat { font-size: 0.85rem; color: var(--text-secondary); }
+
+    .preview-wrap { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+    .preview { background: var(--bg-tertiary); border: 1px dashed rgba(255,255,255,0.2); border-radius: var(--radius-lg); min-height: 220px; display: flex; align-items: center; justify-content: center; overflow: auto; position: relative; }
+    .preview .resizable { resize: both; overflow: auto; display: inline-block; }
+    .preview img, .preview canvas { width: 100%; height: 100%; display: block; object-fit: contain; }
+    .badge { position: absolute; top: 8px; left: 8px; background: rgba(255,255,255,0.06); padding: 4px 8px; border-radius: 999px; font-size: 12px; color: var(--text-primary); border: 1px solid rgba(255,255,255,0.12); }
+
+    .actions { display: flex; gap: 10px; }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 10px 14px; border-radius: var(--radius-md); background: var(--primary-color); color: #fff; border: 1px solid transparent; cursor: pointer; font-weight: 600; transition: all .2s ease; }
+    .btn:hover { transform: translateY(-1px); box-shadow: var(--shadow-md); }
+    .btn.secondary { background: transparent; color: var(--text-primary); border-color: rgba(255,255,255,0.15); }
+    .btn[disabled] { opacity: 0.6; cursor: not-allowed; }
+
+    .note { font-size: 12px; color: var(--text-secondary); }
+    .preview .note { pointer-events: none; }
+    .preview.has-image .note { display: none !important; }
+    .hidden { display: none !important; }
+    .resizable { box-sizing: border-box; padding: 0; border: 0; }
+    .resizable, .resizable * { transition: none !important; }
+    .resizable > img { display: block; width: 100%; height: 100%; object-fit: contain; }
+
+
+    @media (max-width: 900px) { .preview-wrap { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <!-- Animated Background -->
+  <div class="animated-bg">
+    <div class="floating-shapes">
+      <div class="shape shape-1"></div>
+      <div class="shape shape-2"></div>
+      <div class="shape shape-3"></div>
+      <div class="shape shape-4"></div>
+      <div class="shape shape-5"></div>
+    </div>
+  </div>
+
+  <!-- Back Button -->
+  <a href="../../index.html" class="back-button"><i class="fas fa-arrow-left"></i> Back to Tools</a>
+
+  <div class="tool-container">
+    <div class="tool-header">
+      <h1 class="tool-title">Image Compressor</h1>
+      <p class="tool-subtitle">Compress JPG/PNG images in your browser. Adjust quality, optionally resize, and download instantly. All processing happens locally.</p>
+    </div>
+
+    <main>
+      <section class="panel">
+        <div class="row">
+          <div>
+            <label class="label" for="fileInput">Select image (JPG or PNG)</label>
+            <input id="fileInput" type="file" accept="image/jpeg,image/png" />
+            <div class="note">We process images entirely in your browser. No upload to a server.</div>
+          </div>
+          <div class="controls">
+            <div class="slider-row">
+              <span class="label">Quality</span>
+              <input id="quality" type="range" min="1" max="100" value="80" />
+              <input id="qualityValue" class="readonly-value" type="text" value="80%" aria-label="quality value" readonly />
+            </div>
+            <div class="row tight">
+              <div>
+                <label class="label" for="format">Output format</label>
+                <select id="format">
+                  <option value="auto" selected>Auto (keep or switch to JPEG for compression)</option>
+                  <option value="image/jpeg">JPEG (.jpg)</option>
+                  <option value="image/png">PNG (.png)</option>
+                </select>
+              </div>
+              <div>
+                <label class="label" for="maxWidth">Max width (px)</label>
+                <input id="maxWidth" type="number" min="1" placeholder="e.g., 1920 (optional)" />
+              </div>
+              <div>
+                <label class="label" for="maxHeight">Max height (px)</label>
+                <input id="maxHeight" type="number" min="1" placeholder="e.g., 1080 (optional)" />
+              </div>
+              <div style="display:flex; align-items:center; gap:8px;">
+                <input id="keepAspect" type="checkbox" checked />
+                <label class="label" for="keepAspect" style="margin:0;">Keep aspect ratio</label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel preview-wrap">
+        <div class="preview" id="origPreview">
+          <span class="badge">Original</span>
+          <span class="note">No image selected</span>
+        </div>
+        <div class="preview" id="compPreview">
+          <span class="badge">Compressed</span>
+          <span class="note">Adjust settings to compress</span>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="row" style="align-items:flex-end;">
+          <div style="flex:2;">
+            <div class="stat" id="infoOriginal">Original: —</div>
+            <div class="stat" id="infoCompressed">Compressed: —</div>
+            <div class="stat" id="infoSavings">Savings: —</div>
+            <div class="note hidden" id="transparencyNote">Note: PNG transparency may be lost when converting to JPEG.</div>
+          </div>
+          <div class="actions">
+            <button id="compressBtn" class="btn" disabled><i class="fas fa-compress"></i> Compress</button>
+            <a id="downloadLink" class="btn secondary" download disabled><i class="fas fa-download"></i> Download</a>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/tools/image-compressor/script.js
+++ b/tools/image-compressor/script.js
@@ -281,12 +281,11 @@
         downloadLink.removeAttribute('disabled');
     }
 
-    function onFileChange() {
-        const f = fileInput.files && fileInput.files[0];
+    function processSelectedFile(f) {
         if (!f) return;
         if (!/^image\/(png|jpeg)$/.test(f.type)) {
             alert('Please select a JPG or PNG image.');
-            fileInput.value = '';
+            if (fileInput) fileInput.value = '';
             return;
         }
         originalFile = f;
@@ -310,6 +309,11 @@
         }).catch(() => {
             alert('Failed to load image.');
         });
+    }
+
+    function onFileChange() {
+        const f = fileInput.files && fileInput.files[0];
+        processSelectedFile(f);
     }
 
     function onQualityInput() {
@@ -387,7 +391,45 @@
     }, 200);
 
     // Events
-    fileInput.addEventListener('change', onFileChange);
+    if (fileInput) fileInput.addEventListener('change', onFileChange);
+
+    // Use Original preview as uploader (click and drag-drop)
+    if (origPreview) {
+        origPreview.addEventListener('click', () => {
+            if (fileInput) fileInput.click();
+        });
+        origPreview.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                if (fileInput) fileInput.click();
+            }
+        });
+        const setDrag = (on) => {
+            if (on) origPreview.classList.add('dragover'); else origPreview.classList.remove('dragover');
+        };
+        ['dragenter','dragover'].forEach(type => {
+            origPreview.addEventListener(type, (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setDrag(true);
+            });
+        });
+        ['dragleave','dragend','drop'].forEach(type => {
+            origPreview.addEventListener(type, (e) => {
+                if (type !== 'drop') setDrag(false);
+            });
+        });
+        origPreview.addEventListener('drop', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setDrag(false);
+            const files = e.dataTransfer && e.dataTransfer.files;
+            if (!files || !files.length) return;
+            const f = files[0];
+            processSelectedFile(f);
+        });
+    }
+
     qualityRange.addEventListener('input', () => {
         onQualityInput();
     });

--- a/tools/image-compressor/script.js
+++ b/tools/image-compressor/script.js
@@ -1,0 +1,421 @@
+(function () {
+    const fileInput = document.getElementById('fileInput');
+    const qualityRange = document.getElementById('quality');
+    const qualityValue = document.getElementById('qualityValue');
+    const formatSel = document.getElementById('format');
+    const maxWidthEl = document.getElementById('maxWidth');
+    const maxHeightEl = document.getElementById('maxHeight');
+    const keepAspectEl = document.getElementById('keepAspect');
+    const origPreview = document.getElementById('origPreview');
+    const compPreview = document.getElementById('compPreview');
+    const compressBtn = document.getElementById('compressBtn');
+    const downloadLink = document.getElementById('downloadLink');
+    const infoOriginal = document.getElementById('infoOriginal');
+    const infoCompressed = document.getElementById('infoCompressed');
+    const infoSavings = document.getElementById('infoSavings');
+    const transparencyNote = document.getElementById('transparencyNote');
+
+    let originalFile = null;
+    let originalImg = null;
+    let compressedBlob = null;
+    let compressedURL = null;
+    let resizableComp = null;
+    let resizableOrig = null;
+    let compResizeObserver = null;
+    let lastBoxW = null, lastBoxH = null;
+    let isProgrammaticResize = false;
+
+    function setupCompResizeObserver(box) {
+        if (compResizeObserver) compResizeObserver.disconnect();
+
+        const onResize = (entries) => {
+            if (!entries || !entries[0] || isProgrammaticResize) return;
+
+            // Read the size the browser actually paints (avoids subpixel & box-model drift)
+            let newW = box.offsetWidth;
+            let newH = box.offsetHeight;
+
+            // Guard against tiny oscillations from rounding/scrollbar jitters
+            if (lastBoxW != null && lastBoxH != null) {
+                const jitter = Math.abs(newW - lastBoxW) + Math.abs(newH - lastBoxH);
+                if (jitter <= 1) return;
+            }
+
+            const keepAspect = !!(keepAspectEl && keepAspectEl.checked);
+
+
+            // Update inputs only if changed (avoid flicker)
+            if (maxWidthEl.value !== String(newW)) maxWidthEl.value = String(newW);
+            if (maxHeightEl.value !== String(newH)) maxHeightEl.value = String(newH);
+
+            lastBoxW = newW;
+            lastBoxH = newH;
+
+            // Keep original preview the exact same display size
+            if (resizableOrig) {
+                resizableOrig.style.width = newW + 'px';
+                resizableOrig.style.height = newH + 'px';
+            }
+
+            // Do not recompress mid-drag (your previous guard)
+            debouncedCompress();
+        };
+
+        // Throttle to frame rate to avoid “mid-frame” mismatches
+        let rafId = null;
+        compResizeObserver = new ResizeObserver((entries) => {
+            if (rafId) return;
+            rafId = requestAnimationFrame(() => {
+                rafId = null;
+                onResize(entries);
+            });
+        });
+
+        compResizeObserver.observe(box);
+    }
+
+
+    function bytesToNice(bytes) {
+        if (bytes == null) return '—';
+        const units = ['B', 'KB', 'MB', 'GB'];
+        let i = 0;
+        let num = bytes;
+        while (num >= 1024 && i < units.length - 1) {
+            num /= 1024;
+            i++;
+        }
+        return num.toFixed(num < 10 && i > 0 ? 2 : 0) + ' ' + units[i];
+    }
+
+    function clearPreview(el) {
+        [...el.querySelectorAll('img,canvas,.resizable')].forEach(n => n.remove());
+        el.classList.remove('has-image');
+    }
+
+    function showImageIn(el, src, w, h) {
+        if (el === origPreview) {
+            // Render original inside a resizable box that mirrors the compressed size
+            clearPreview(el);
+            let box = resizableOrig;
+            if (!box) {
+                box = document.createElement('div');
+                box.className = 'resizable';
+                resizableOrig = box;
+            }
+            const img = document.createElement('img');
+            img.alt = 'preview';
+            img.src = src;
+            // If compressed box exists, match its current size, otherwise use provided or natural
+            let ow = (resizableComp && resizableComp.offsetWidth) || (typeof w === 'number' ? w : undefined);
+            let oh = (resizableComp && resizableComp.offsetHeight) || (typeof h === 'number' ? h : undefined);
+            if (ow) box.style.width = ow + 'px';
+            if (oh) box.style.height = oh + 'px';
+            box.innerHTML = '';
+            box.appendChild(img);
+            el.appendChild(box);
+            el.classList.add('has-image');
+            return;
+        }
+
+        let box = resizableComp;
+        if (!box) {
+            // first time create
+            box = document.createElement('div');
+            box.className = 'resizable';
+            if (typeof w === 'number' && w > 0) box.style.width = w + 'px';
+            if (typeof h === 'number' && h > 0) box.style.height = h + 'px';
+
+            const img = document.createElement('img');
+            img.alt = 'preview';
+            img.src = src;
+            box.appendChild(img);
+
+            resizableComp = box;
+            if (el !== box.parentNode) el.appendChild(box);
+            el.classList.add('has-image');
+
+            // set aspect ratio constraint if needed
+            updateResizableAspect();
+
+            // (re)attach observer
+            setupCompResizeObserver(box);
+            lastBoxW = (typeof w === 'number' ? w : null);
+            lastBoxH = (typeof h === 'number' ? h : null);
+            return;
+        }
+
+        // reuse existing box + img
+        let img = box.querySelector('img');
+        if (!img) {
+            img = document.createElement('img');
+            img.alt = 'preview';
+            box.appendChild(img);
+        }
+
+        // refresh aspect ratio constraint (in case checkbox changed)
+        updateResizableAspect();
+
+        if (typeof w === 'number' && w > 0) box.style.width = w + 'px';
+        if (typeof h === 'number' && h > 0) box.style.height = h + 'px';
+        if (img.src !== src) img.src = src;
+
+        if (box.parentNode !== el) {
+            el.appendChild(box);
+            el.classList.add('has-image');
+        }
+    }
+
+
+    function loadImage(file) {
+        return new Promise((resolve, reject) => {
+            const url = URL.createObjectURL(file);
+            const img = new Image();
+            img.onload = () => {
+                URL.revokeObjectURL(url);
+                resolve(img);
+            };
+            img.onerror = (e) => {
+                URL.revokeObjectURL(url);
+                reject(e);
+            };
+            img.src = url;
+        });
+    }
+
+    function computeTargetSize(srcW, srcH, maxW, maxH, keepAspect) {
+        if (!maxW && !maxH) return {w: srcW, h: srcH};
+        let w = srcW, h = srcH;
+        if (keepAspect !== false) {
+            if (maxW && w > maxW) {
+                const scale = maxW / w;
+                w = maxW;
+                h = Math.round(h * scale);
+            }
+            if (maxH && h > maxH) {
+                const scale = maxH / h;
+                h = maxH;
+                w = Math.round(w * scale);
+            }
+        } else {
+            if (maxW && w > maxW) {
+                w = maxW;
+            }
+            if (maxH && h > maxH) {
+                h = maxH;
+            }
+        }
+        return {w, h};
+    }
+
+    async function compress() {
+        if (!originalFile || !originalImg) return;
+
+        const srcType = originalFile.type; // image/jpeg or image/png
+        let targetType = formatSel.value;
+        if (targetType === 'auto') {
+            // If JPEG, keep JPEG. If PNG, convert to JPEG to allow quality compression.
+            targetType = srcType === 'image/jpeg' ? 'image/jpeg' : 'image/jpeg';
+        }
+
+        // transparency notice
+        const willLoseAlpha = (srcType === 'image/png') && (targetType === 'image/jpeg');
+        transparencyNote.style.display = willLoseAlpha ? 'block' : 'none';
+
+        const q = Math.min(100, Math.max(1, parseInt(qualityRange.value, 10) || 80)) / 100;
+
+        const maxW = parseInt(maxWidthEl.value, 10);
+        const maxH = parseInt(maxHeightEl.value, 10);
+
+        const keepAspect = keepAspectEl ? !!keepAspectEl.checked : true;
+        const {
+            w: dstW,
+            h: dstH
+        } = computeTargetSize(originalImg.naturalWidth, originalImg.naturalHeight, maxW, maxH, keepAspect);
+
+        const canvas = document.createElement('canvas');
+        canvas.width = dstW;
+        canvas.height = dstH;
+        const ctx = canvas.getContext('2d');
+
+        if (willLoseAlpha) {
+            // fill with white to avoid black background where transparent
+            ctx.fillStyle = '#ffffff';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+        }
+        ctx.drawImage(originalImg, 0, 0, dstW, dstH);
+
+        const blob = await new Promise((resolve) => canvas.toBlob(resolve, targetType, q));
+        if (!blob) {
+            alert('Compression failed. Try different settings.');
+            return;
+        }
+
+        // Revoke previous
+        if (compressedURL) {
+            URL.revokeObjectURL(compressedURL);
+        }
+        compressedBlob = blob;
+        compressedURL = URL.createObjectURL(blob);
+
+        // show preview
+        showImageIn(compPreview, compressedURL, dstW, dstH);
+        // ensure original display matches compressed size
+        if (resizableOrig) {
+            resizableOrig.style.width = dstW + 'px';
+            resizableOrig.style.height = dstH + 'px';
+        }
+
+        // update stats
+        infoOriginal.textContent = `Original: ${originalImg.naturalWidth}×${originalImg.naturalHeight}, ${bytesToNice(originalFile.size)}`;
+        infoCompressed.textContent = `Compressed: ${dstW}×${dstH}, ${bytesToNice(blob.size)}`;
+        const diff = originalFile.size - blob.size;
+        const pct = originalFile.size > 0 ? Math.round((diff / originalFile.size) * 100) : 0;
+        const sign = diff >= 0 ? 'reduction' : 'increase';
+        infoSavings.textContent = `Savings: ${bytesToNice(Math.abs(diff))} (${Math.abs(pct)}% ${sign})`;
+
+        // enable download
+        const baseName = (originalFile.name || 'image').replace(/\.[^.]+$/, '');
+        const ext = targetType === 'image/png' ? 'png' : 'jpg';
+        downloadLink.href = compressedURL;
+        downloadLink.download = `${baseName}-compressed.${ext}`;
+        downloadLink.removeAttribute('disabled');
+    }
+
+    function onFileChange() {
+        const f = fileInput.files && fileInput.files[0];
+        if (!f) return;
+        if (!/^image\/(png|jpeg)$/.test(f.type)) {
+            alert('Please select a JPG or PNG image.');
+            fileInput.value = '';
+            return;
+        }
+        originalFile = f;
+        loadImage(f).then(img => {
+            originalImg = img;
+            // show original preview
+            const url = URL.createObjectURL(f);
+            showImageIn(origPreview, url, img.naturalWidth, img.naturalHeight);
+
+            // set initial width/height inputs to the original image size
+            maxWidthEl.value = String(img.naturalWidth);
+            maxHeightEl.value = String(img.naturalHeight);
+            // Fill initial info
+            infoOriginal.textContent = `Original: ${img.naturalWidth}×${img.naturalHeight}, ${bytesToNice(f.size)}`;
+            infoCompressed.textContent = 'Compressed: —';
+            infoSavings.textContent = 'Savings: —';
+            // Enable actions
+            compressBtn.disabled = false;
+            // Auto-run compression once
+            compress();
+        }).catch(() => {
+            alert('Failed to load image.');
+        });
+    }
+
+    function onQualityInput() {
+        const v = Math.min(100, Math.max(1, parseInt(qualityRange.value, 10) || 80));
+        qualityValue.value = v + '%';
+    }
+
+    function debounce(fn, ms) {
+        let t;
+        return function () {
+            clearTimeout(t);
+            const args = arguments;
+            const ctx = this;
+            t = setTimeout(() => fn.apply(ctx, args), ms);
+        };
+    }
+
+    function syncResizableFromInputs() {
+        if (!resizableComp || !originalImg) return;
+        const cr = resizableComp.getBoundingClientRect();
+
+        let w = parseInt(maxWidthEl.value, 10);
+        let h = parseInt(maxHeightEl.value, 10);
+        const hasW = Number.isFinite(w) && w > 0;
+        const hasH = Number.isFinite(h) && h > 0;
+        const keepAspect = !!(keepAspectEl && keepAspectEl.checked);
+
+        if (keepAspect && originalImg) {
+            const aspect = originalImg.naturalWidth / originalImg.naturalHeight;
+            if (hasW && !hasH) h = Math.round(w / aspect);
+            else if (hasH && !hasW) w = Math.round(h * aspect);
+            else if (!hasW && !hasH) {
+                w = originalImg.naturalWidth;
+                h = originalImg.naturalHeight;
+            } else {
+                // both provided: ensure consistency
+                h = Math.round(w / aspect);
+            }
+        } else {
+            // no-aspect: respect only what the user set
+            if (!hasW) w = Math.max(1, Math.round(cr.width));
+            if (!hasH) h = Math.max(1, Math.round(cr.height));
+        }
+
+        isProgrammaticResize = true;
+        resizableComp.style.width = w + 'px';
+        resizableComp.style.height = h + 'px';
+        // mirror to original preview size
+        if (resizableOrig) {
+            resizableOrig.style.width = w + 'px';
+            resizableOrig.style.height = h + 'px';
+        }
+        lastBoxW = w;
+        lastBoxH = h;
+        // release the guard after layout flush
+        requestAnimationFrame(() => {
+            isProgrammaticResize = false;
+        });
+    }
+
+    function updateResizableAspect() {
+        if (!resizableComp) {
+            return;
+        }
+        if (!originalImg) {
+            resizableComp.style.aspectRatio = '';
+            return;
+        }
+        const keep = keepAspectEl ? !!keepAspectEl.checked : true;
+        resizableComp.style.aspectRatio = keep ? (originalImg.naturalWidth + ' / ' + originalImg.naturalHeight) : '';
+    }
+
+    const debouncedCompress = debounce(() => {
+        if (originalFile) compress();
+    }, 200);
+
+    // Events
+    fileInput.addEventListener('change', onFileChange);
+    qualityRange.addEventListener('input', () => {
+        onQualityInput();
+    });
+    qualityRange.addEventListener('change', debounce(() => {
+        if (originalFile) compress();
+    }, 150));
+    formatSel.addEventListener('change', () => {
+        if (originalFile) compress();
+    });
+    const onDimInput = () => {
+        syncResizableFromInputs();
+        debouncedCompress();
+    };
+    maxWidthEl.addEventListener('input', onDimInput);
+    maxWidthEl.addEventListener('change', onDimInput);
+    maxHeightEl.addEventListener('input', onDimInput);
+    maxHeightEl.addEventListener('change', onDimInput);
+    if (keepAspectEl) {
+        keepAspectEl.addEventListener('change', () => {
+            updateResizableAspect();
+            syncResizableFromInputs();
+            debouncedCompress();
+        });
+    }
+    compressBtn.addEventListener('click', () => {
+        compress();
+    });
+
+    // Initialize
+    onQualityInput();
+})();

--- a/tools/image-compressor/script.js
+++ b/tools/image-compressor/script.js
@@ -1,463 +1,461 @@
-(function () {
-    const fileInput = document.getElementById('fileInput');
-    const qualityRange = document.getElementById('quality');
-    const qualityValue = document.getElementById('qualityValue');
-    const formatSel = document.getElementById('format');
-    const maxWidthEl = document.getElementById('maxWidth');
-    const maxHeightEl = document.getElementById('maxHeight');
-    const keepAspectEl = document.getElementById('keepAspect');
-    const origPreview = document.getElementById('origPreview');
-    const compPreview = document.getElementById('compPreview');
-    const compressBtn = document.getElementById('compressBtn');
-    const downloadLink = document.getElementById('downloadLink');
-    const infoOriginal = document.getElementById('infoOriginal');
-    const infoCompressed = document.getElementById('infoCompressed');
-    const infoSavings = document.getElementById('infoSavings');
-    const transparencyNote = document.getElementById('transparencyNote');
+const fileInput = document.getElementById('fileInput');
+const qualityRange = document.getElementById('quality');
+const qualityValue = document.getElementById('qualityValue');
+const formatSel = document.getElementById('format');
+const maxWidthEl = document.getElementById('maxWidth');
+const maxHeightEl = document.getElementById('maxHeight');
+const keepAspectEl = document.getElementById('keepAspect');
+const origPreview = document.getElementById('origPreview');
+const compPreview = document.getElementById('compPreview');
+const compressBtn = document.getElementById('compressBtn');
+const downloadLink = document.getElementById('downloadLink');
+const infoOriginal = document.getElementById('infoOriginal');
+const infoCompressed = document.getElementById('infoCompressed');
+const infoSavings = document.getElementById('infoSavings');
+const transparencyNote = document.getElementById('transparencyNote');
 
-    let originalFile = null;
-    let originalImg = null;
-    let compressedBlob = null;
-    let compressedURL = null;
-    let resizableComp = null;
-    let resizableOrig = null;
-    let compResizeObserver = null;
-    let lastBoxW = null, lastBoxH = null;
-    let isProgrammaticResize = false;
+let originalFile = null;
+let originalImg = null;
+let compressedBlob = null;
+let compressedURL = null;
+let resizableComp = null;
+let resizableOrig = null;
+let compResizeObserver = null;
+let lastBoxW = null, lastBoxH = null;
+let isProgrammaticResize = false;
 
-    function setupCompResizeObserver(box) {
-        if (compResizeObserver) compResizeObserver.disconnect();
+function setupCompResizeObserver(box) {
+    if (compResizeObserver) compResizeObserver.disconnect();
 
-        const onResize = (entries) => {
-            if (!entries || !entries[0] || isProgrammaticResize) return;
+    const onResize = (entries) => {
+        if (!entries || !entries[0] || isProgrammaticResize) return;
 
-            // Read the size the browser actually paints (avoids subpixel & box-model drift)
-            let newW = box.offsetWidth;
-            let newH = box.offsetHeight;
+        // Read the size the browser actually paints (avoids subpixel & box-model drift)
+        let newW = box.offsetWidth;
+        let newH = box.offsetHeight;
 
-            // Guard against tiny oscillations from rounding/scrollbar jitters
-            if (lastBoxW != null && lastBoxH != null) {
-                const jitter = Math.abs(newW - lastBoxW) + Math.abs(newH - lastBoxH);
-                if (jitter <= 1) return;
-            }
-
-            const keepAspect = !!(keepAspectEl && keepAspectEl.checked);
-
-
-            // Update inputs only if changed (avoid flicker)
-            if (maxWidthEl.value !== String(newW)) maxWidthEl.value = String(newW);
-            if (maxHeightEl.value !== String(newH)) maxHeightEl.value = String(newH);
-
-            lastBoxW = newW;
-            lastBoxH = newH;
-
-            // Keep original preview the exact same display size
-            if (resizableOrig) {
-                resizableOrig.style.width = newW + 'px';
-                resizableOrig.style.height = newH + 'px';
-            }
-
-            // Do not recompress mid-drag (your previous guard)
-            debouncedCompress();
-        };
-
-        // Throttle to frame rate to avoid “mid-frame” mismatches
-        let rafId = null;
-        compResizeObserver = new ResizeObserver((entries) => {
-            if (rafId) return;
-            rafId = requestAnimationFrame(() => {
-                rafId = null;
-                onResize(entries);
-            });
-        });
-
-        compResizeObserver.observe(box);
-    }
-
-
-    function bytesToNice(bytes) {
-        if (bytes == null) return '—';
-        const units = ['B', 'KB', 'MB', 'GB'];
-        let i = 0;
-        let num = bytes;
-        while (num >= 1024 && i < units.length - 1) {
-            num /= 1024;
-            i++;
-        }
-        return num.toFixed(num < 10 && i > 0 ? 2 : 0) + ' ' + units[i];
-    }
-
-    function clearPreview(el) {
-        [...el.querySelectorAll('img,canvas,.resizable')].forEach(n => n.remove());
-        el.classList.remove('has-image');
-    }
-
-    function showImageIn(el, src, w, h) {
-        if (el === origPreview) {
-            // Render original inside a resizable box that mirrors the compressed size
-            clearPreview(el);
-            let box = resizableOrig;
-            if (!box) {
-                box = document.createElement('div');
-                box.className = 'resizable';
-                resizableOrig = box;
-            }
-            const img = document.createElement('img');
-            img.alt = 'preview';
-            img.src = src;
-            // If compressed box exists, match its current size, otherwise use provided or natural
-            let ow = (resizableComp && resizableComp.offsetWidth) || (typeof w === 'number' ? w : undefined);
-            let oh = (resizableComp && resizableComp.offsetHeight) || (typeof h === 'number' ? h : undefined);
-            if (ow) box.style.width = ow + 'px';
-            if (oh) box.style.height = oh + 'px';
-            box.innerHTML = '';
-            box.appendChild(img);
-            el.appendChild(box);
-            el.classList.add('has-image');
-            return;
+        // Guard against tiny oscillations from rounding/scrollbar jitters
+        if (lastBoxW != null && lastBoxH != null) {
+            const jitter = Math.abs(newW - lastBoxW) + Math.abs(newH - lastBoxH);
+            if (jitter <= 1) return;
         }
 
-        let box = resizableComp;
-        if (!box) {
-            // first time create
-            box = document.createElement('div');
-            box.className = 'resizable';
-            if (typeof w === 'number' && w > 0) box.style.width = w + 'px';
-            if (typeof h === 'number' && h > 0) box.style.height = h + 'px';
-
-            const img = document.createElement('img');
-            img.alt = 'preview';
-            img.src = src;
-            box.appendChild(img);
-
-            resizableComp = box;
-            if (el !== box.parentNode) el.appendChild(box);
-            el.classList.add('has-image');
-
-            // set aspect ratio constraint if needed
-            updateResizableAspect();
-
-            // (re)attach observer
-            setupCompResizeObserver(box);
-            lastBoxW = (typeof w === 'number' ? w : null);
-            lastBoxH = (typeof h === 'number' ? h : null);
-            return;
-        }
-
-        // reuse existing box + img
-        let img = box.querySelector('img');
-        if (!img) {
-            img = document.createElement('img');
-            img.alt = 'preview';
-            box.appendChild(img);
-        }
-
-        // refresh aspect ratio constraint (in case checkbox changed)
-        updateResizableAspect();
-
-        if (typeof w === 'number' && w > 0) box.style.width = w + 'px';
-        if (typeof h === 'number' && h > 0) box.style.height = h + 'px';
-        if (img.src !== src) img.src = src;
-
-        if (box.parentNode !== el) {
-            el.appendChild(box);
-            el.classList.add('has-image');
-        }
-    }
-
-
-    function loadImage(file) {
-        return new Promise((resolve, reject) => {
-            const url = URL.createObjectURL(file);
-            const img = new Image();
-            img.onload = () => {
-                URL.revokeObjectURL(url);
-                resolve(img);
-            };
-            img.onerror = (e) => {
-                URL.revokeObjectURL(url);
-                reject(e);
-            };
-            img.src = url;
-        });
-    }
-
-    function computeTargetSize(srcW, srcH, maxW, maxH, keepAspect) {
-        if (!maxW && !maxH) return {w: srcW, h: srcH};
-        let w = srcW, h = srcH;
-        if (keepAspect !== false) {
-            if (maxW && w > maxW) {
-                const scale = maxW / w;
-                w = maxW;
-                h = Math.round(h * scale);
-            }
-            if (maxH && h > maxH) {
-                const scale = maxH / h;
-                h = maxH;
-                w = Math.round(w * scale);
-            }
-        } else {
-            if (maxW && w > maxW) {
-                w = maxW;
-            }
-            if (maxH && h > maxH) {
-                h = maxH;
-            }
-        }
-        return {w, h};
-    }
-
-    async function compress() {
-        if (!originalFile || !originalImg) return;
-
-        const srcType = originalFile.type; // image/jpeg or image/png
-        let targetType = formatSel.value;
-        if (targetType === 'auto') {
-            // If JPEG, keep JPEG. If PNG, convert to JPEG to allow quality compression.
-            targetType = srcType === 'image/jpeg' ? 'image/jpeg' : 'image/jpeg';
-        }
-
-        // transparency notice
-        const willLoseAlpha = (srcType === 'image/png') && (targetType === 'image/jpeg');
-        transparencyNote.style.display = willLoseAlpha ? 'block' : 'none';
-
-        const q = Math.min(100, Math.max(1, parseInt(qualityRange.value, 10) || 80)) / 100;
-
-        const maxW = parseInt(maxWidthEl.value, 10);
-        const maxH = parseInt(maxHeightEl.value, 10);
-
-        const keepAspect = keepAspectEl ? !!keepAspectEl.checked : true;
-        const {
-            w: dstW,
-            h: dstH
-        } = computeTargetSize(originalImg.naturalWidth, originalImg.naturalHeight, maxW, maxH, keepAspect);
-
-        const canvas = document.createElement('canvas');
-        canvas.width = dstW;
-        canvas.height = dstH;
-        const ctx = canvas.getContext('2d');
-
-        if (willLoseAlpha) {
-            // fill with white to avoid black background where transparent
-            ctx.fillStyle = '#ffffff';
-            ctx.fillRect(0, 0, canvas.width, canvas.height);
-        }
-        ctx.drawImage(originalImg, 0, 0, dstW, dstH);
-
-        const blob = await new Promise((resolve) => canvas.toBlob(resolve, targetType, q));
-        if (!blob) {
-            alert('Compression failed. Try different settings.');
-            return;
-        }
-
-        // Revoke previous
-        if (compressedURL) {
-            URL.revokeObjectURL(compressedURL);
-        }
-        compressedBlob = blob;
-        compressedURL = URL.createObjectURL(blob);
-
-        // show preview
-        showImageIn(compPreview, compressedURL, dstW, dstH);
-        // ensure original display matches compressed size
-        if (resizableOrig) {
-            resizableOrig.style.width = dstW + 'px';
-            resizableOrig.style.height = dstH + 'px';
-        }
-
-        // update stats
-        infoOriginal.textContent = `Original: ${originalImg.naturalWidth}×${originalImg.naturalHeight}, ${bytesToNice(originalFile.size)}`;
-        infoCompressed.textContent = `Compressed: ${dstW}×${dstH}, ${bytesToNice(blob.size)}`;
-        const diff = originalFile.size - blob.size;
-        const pct = originalFile.size > 0 ? Math.round((diff / originalFile.size) * 100) : 0;
-        const sign = diff >= 0 ? 'reduction' : 'increase';
-        infoSavings.textContent = `Savings: ${bytesToNice(Math.abs(diff))} (${Math.abs(pct)}% ${sign})`;
-
-        // enable download
-        const baseName = (originalFile.name || 'image').replace(/\.[^.]+$/, '');
-        const ext = targetType === 'image/png' ? 'png' : 'jpg';
-        downloadLink.href = compressedURL;
-        downloadLink.download = `${baseName}-compressed.${ext}`;
-        downloadLink.removeAttribute('disabled');
-    }
-
-    function processSelectedFile(f) {
-        if (!f) return;
-        if (!/^image\/(png|jpeg)$/.test(f.type)) {
-            alert('Please select a JPG or PNG image.');
-            if (fileInput) fileInput.value = '';
-            return;
-        }
-        originalFile = f;
-        loadImage(f).then(img => {
-            originalImg = img;
-            // show original preview
-            const url = URL.createObjectURL(f);
-            showImageIn(origPreview, url, img.naturalWidth, img.naturalHeight);
-
-            // set initial width/height inputs to the original image size
-            maxWidthEl.value = String(img.naturalWidth);
-            maxHeightEl.value = String(img.naturalHeight);
-            // Fill initial info
-            infoOriginal.textContent = `Original: ${img.naturalWidth}×${img.naturalHeight}, ${bytesToNice(f.size)}`;
-            infoCompressed.textContent = 'Compressed: —';
-            infoSavings.textContent = 'Savings: —';
-            // Enable actions
-            compressBtn.disabled = false;
-            // Auto-run compression once
-            compress();
-        }).catch(() => {
-            alert('Failed to load image.');
-        });
-    }
-
-    function onFileChange() {
-        const f = fileInput.files && fileInput.files[0];
-        processSelectedFile(f);
-    }
-
-    function onQualityInput() {
-        const v = Math.min(100, Math.max(1, parseInt(qualityRange.value, 10) || 80));
-        qualityValue.value = v + '%';
-    }
-
-    function debounce(fn, ms) {
-        let t;
-        return function () {
-            clearTimeout(t);
-            const args = arguments;
-            const ctx = this;
-            t = setTimeout(() => fn.apply(ctx, args), ms);
-        };
-    }
-
-    function syncResizableFromInputs() {
-        if (!resizableComp || !originalImg) return;
-        const cr = resizableComp.getBoundingClientRect();
-
-        let w = parseInt(maxWidthEl.value, 10);
-        let h = parseInt(maxHeightEl.value, 10);
-        const hasW = Number.isFinite(w) && w > 0;
-        const hasH = Number.isFinite(h) && h > 0;
         const keepAspect = !!(keepAspectEl && keepAspectEl.checked);
 
-        if (keepAspect && originalImg) {
-            const aspect = originalImg.naturalWidth / originalImg.naturalHeight;
-            if (hasW && !hasH) h = Math.round(w / aspect);
-            else if (hasH && !hasW) w = Math.round(h * aspect);
-            else if (!hasW && !hasH) {
-                w = originalImg.naturalWidth;
-                h = originalImg.naturalHeight;
-            } else {
-                // both provided: ensure consistency
-                h = Math.round(w / aspect);
-            }
-        } else {
-            // no-aspect: respect only what the user set
-            if (!hasW) w = Math.max(1, Math.round(cr.width));
-            if (!hasH) h = Math.max(1, Math.round(cr.height));
-        }
 
-        isProgrammaticResize = true;
-        resizableComp.style.width = w + 'px';
-        resizableComp.style.height = h + 'px';
-        // mirror to original preview size
+        // Update inputs only if changed (avoid flicker)
+        if (maxWidthEl.value !== String(newW)) maxWidthEl.value = String(newW);
+        if (maxHeightEl.value !== String(newH)) maxHeightEl.value = String(newH);
+
+        lastBoxW = newW;
+        lastBoxH = newH;
+
+        // Keep original preview the exact same display size
         if (resizableOrig) {
-            resizableOrig.style.width = w + 'px';
-            resizableOrig.style.height = h + 'px';
+            resizableOrig.style.width = newW + 'px';
+            resizableOrig.style.height = newH + 'px';
         }
-        lastBoxW = w;
-        lastBoxH = h;
-        // release the guard after layout flush
-        requestAnimationFrame(() => {
-            isProgrammaticResize = false;
-        });
-    }
 
-    function updateResizableAspect() {
-        if (!resizableComp) {
-            return;
-        }
-        if (!originalImg) {
-            resizableComp.style.aspectRatio = '';
-            return;
-        }
-        const keep = keepAspectEl ? !!keepAspectEl.checked : true;
-        resizableComp.style.aspectRatio = keep ? (originalImg.naturalWidth + ' / ' + originalImg.naturalHeight) : '';
-    }
-
-    const debouncedCompress = debounce(() => {
-        if (originalFile) compress();
-    }, 200);
-
-    // Events
-    if (fileInput) fileInput.addEventListener('change', onFileChange);
-
-    // Use Original preview as uploader (click and drag-drop)
-    if (origPreview) {
-        origPreview.addEventListener('click', () => {
-            if (fileInput) fileInput.click();
-        });
-        origPreview.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                if (fileInput) fileInput.click();
-            }
-        });
-        const setDrag = (on) => {
-            if (on) origPreview.classList.add('dragover'); else origPreview.classList.remove('dragover');
-        };
-        ['dragenter','dragover'].forEach(type => {
-            origPreview.addEventListener(type, (e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                setDrag(true);
-            });
-        });
-        ['dragleave','dragend','drop'].forEach(type => {
-            origPreview.addEventListener(type, (e) => {
-                if (type !== 'drop') setDrag(false);
-            });
-        });
-        origPreview.addEventListener('drop', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            setDrag(false);
-            const files = e.dataTransfer && e.dataTransfer.files;
-            if (!files || !files.length) return;
-            const f = files[0];
-            processSelectedFile(f);
-        });
-    }
-
-    qualityRange.addEventListener('input', () => {
-        onQualityInput();
-    });
-    qualityRange.addEventListener('change', debounce(() => {
-        if (originalFile) compress();
-    }, 150));
-    formatSel.addEventListener('change', () => {
-        if (originalFile) compress();
-    });
-    const onDimInput = () => {
-        syncResizableFromInputs();
+        // Do not recompress mid-drag (your previous guard)
         debouncedCompress();
     };
-    maxWidthEl.addEventListener('input', onDimInput);
-    maxWidthEl.addEventListener('change', onDimInput);
-    maxHeightEl.addEventListener('input', onDimInput);
-    maxHeightEl.addEventListener('change', onDimInput);
-    if (keepAspectEl) {
-        keepAspectEl.addEventListener('change', () => {
-            updateResizableAspect();
-            syncResizableFromInputs();
-            debouncedCompress();
+
+    // Throttle to frame rate to avoid “mid-frame” mismatches
+    let rafId = null;
+    compResizeObserver = new ResizeObserver((entries) => {
+        if (rafId) return;
+        rafId = requestAnimationFrame(() => {
+            rafId = null;
+            onResize(entries);
         });
-    }
-    compressBtn.addEventListener('click', () => {
-        compress();
     });
 
-    // Initialize
+    compResizeObserver.observe(box);
+}
+
+
+function bytesToNice(bytes) {
+    if (bytes == null) return '—';
+    const units = ['B', 'KB', 'MB', 'GB'];
+    let i = 0;
+    let num = bytes;
+    while (num >= 1024 && i < units.length - 1) {
+        num /= 1024;
+        i++;
+    }
+    return num.toFixed(num < 10 && i > 0 ? 2 : 0) + ' ' + units[i];
+}
+
+function clearPreview(el) {
+    [...el.querySelectorAll('img,canvas,.resizable')].forEach(n => n.remove());
+    el.classList.remove('has-image');
+}
+
+function showImageIn(el, src, w, h) {
+    if (el === origPreview) {
+        // Render original inside a resizable box that mirrors the compressed size
+        clearPreview(el);
+        let box = resizableOrig;
+        if (!box) {
+            box = document.createElement('div');
+            box.className = 'resizable';
+            resizableOrig = box;
+        }
+        const img = document.createElement('img');
+        img.alt = 'preview';
+        img.src = src;
+        // If compressed box exists, match its current size, otherwise use provided or natural
+        let ow = (resizableComp && resizableComp.offsetWidth) || (typeof w === 'number' ? w : undefined);
+        let oh = (resizableComp && resizableComp.offsetHeight) || (typeof h === 'number' ? h : undefined);
+        if (ow) box.style.width = ow + 'px';
+        if (oh) box.style.height = oh + 'px';
+        box.innerHTML = '';
+        box.appendChild(img);
+        el.appendChild(box);
+        el.classList.add('has-image');
+        return;
+    }
+
+    let box = resizableComp;
+    if (!box) {
+        // first time create
+        box = document.createElement('div');
+        box.className = 'resizable';
+        if (typeof w === 'number' && w > 0) box.style.width = w + 'px';
+        if (typeof h === 'number' && h > 0) box.style.height = h + 'px';
+
+        const img = document.createElement('img');
+        img.alt = 'preview';
+        img.src = src;
+        box.appendChild(img);
+
+        resizableComp = box;
+        if (el !== box.parentNode) el.appendChild(box);
+        el.classList.add('has-image');
+
+        // set aspect ratio constraint if needed
+        updateResizableAspect();
+
+        // (re)attach observer
+        setupCompResizeObserver(box);
+        lastBoxW = (typeof w === 'number' ? w : null);
+        lastBoxH = (typeof h === 'number' ? h : null);
+        return;
+    }
+
+    // reuse existing box + img
+    let img = box.querySelector('img');
+    if (!img) {
+        img = document.createElement('img');
+        img.alt = 'preview';
+        box.appendChild(img);
+    }
+
+    // refresh aspect ratio constraint (in case checkbox changed)
+    updateResizableAspect();
+
+    if (typeof w === 'number' && w > 0) box.style.width = w + 'px';
+    if (typeof h === 'number' && h > 0) box.style.height = h + 'px';
+    if (img.src !== src) img.src = src;
+
+    if (box.parentNode !== el) {
+        el.appendChild(box);
+        el.classList.add('has-image');
+    }
+}
+
+
+function loadImage(file) {
+    return new Promise((resolve, reject) => {
+        const url = URL.createObjectURL(file);
+        const img = new Image();
+        img.onload = () => {
+            URL.revokeObjectURL(url);
+            resolve(img);
+        };
+        img.onerror = (e) => {
+            URL.revokeObjectURL(url);
+            reject(e);
+        };
+        img.src = url;
+    });
+}
+
+function computeTargetSize(srcW, srcH, maxW, maxH, keepAspect) {
+    if (!maxW && !maxH) return {w: srcW, h: srcH};
+    let w = srcW, h = srcH;
+    if (keepAspect !== false) {
+        if (maxW && w > maxW) {
+            const scale = maxW / w;
+            w = maxW;
+            h = Math.round(h * scale);
+        }
+        if (maxH && h > maxH) {
+            const scale = maxH / h;
+            h = maxH;
+            w = Math.round(w * scale);
+        }
+    } else {
+        if (maxW && w > maxW) {
+            w = maxW;
+        }
+        if (maxH && h > maxH) {
+            h = maxH;
+        }
+    }
+    return {w, h};
+}
+
+async function compress() {
+    if (!originalFile || !originalImg) return;
+
+    const srcType = originalFile.type; // image/jpeg or image/png
+    let targetType = formatSel.value;
+    if (targetType === 'auto') {
+        // If JPEG, keep JPEG. If PNG, convert to JPEG to allow quality compression.
+        targetType = srcType === 'image/jpeg' ? 'image/jpeg' : 'image/jpeg';
+    }
+
+    // transparency notice
+    const willLoseAlpha = (srcType === 'image/png') && (targetType === 'image/jpeg');
+    transparencyNote.style.display = willLoseAlpha ? 'block' : 'none';
+
+    const q = Math.min(100, Math.max(1, parseInt(qualityRange.value, 10) || 80)) / 100;
+
+    const maxW = parseInt(maxWidthEl.value, 10);
+    const maxH = parseInt(maxHeightEl.value, 10);
+
+    const keepAspect = keepAspectEl ? !!keepAspectEl.checked : true;
+    const {
+        w: dstW,
+        h: dstH
+    } = computeTargetSize(originalImg.naturalWidth, originalImg.naturalHeight, maxW, maxH, keepAspect);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = dstW;
+    canvas.height = dstH;
+    const ctx = canvas.getContext('2d');
+
+    if (willLoseAlpha) {
+        // fill with white to avoid black background where transparent
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+    ctx.drawImage(originalImg, 0, 0, dstW, dstH);
+
+    const blob = await new Promise((resolve) => canvas.toBlob(resolve, targetType, q));
+    if (!blob) {
+        alert('Compression failed. Try different settings.');
+        return;
+    }
+
+    // Revoke previous
+    if (compressedURL) {
+        URL.revokeObjectURL(compressedURL);
+    }
+    compressedBlob = blob;
+    compressedURL = URL.createObjectURL(blob);
+
+    // show preview
+    showImageIn(compPreview, compressedURL, dstW, dstH);
+    // ensure original display matches compressed size
+    if (resizableOrig) {
+        resizableOrig.style.width = dstW + 'px';
+        resizableOrig.style.height = dstH + 'px';
+    }
+
+    // update stats
+    infoOriginal.textContent = `Original: ${originalImg.naturalWidth}×${originalImg.naturalHeight}, ${bytesToNice(originalFile.size)}`;
+    infoCompressed.textContent = `Compressed: ${dstW}×${dstH}, ${bytesToNice(blob.size)}`;
+    const diff = originalFile.size - blob.size;
+    const pct = originalFile.size > 0 ? Math.round((diff / originalFile.size) * 100) : 0;
+    const sign = diff >= 0 ? 'reduction' : 'increase';
+    infoSavings.textContent = `Savings: ${bytesToNice(Math.abs(diff))} (${Math.abs(pct)}% ${sign})`;
+
+    // enable download
+    const baseName = (originalFile.name || 'image').replace(/\.[^.]+$/, '');
+    const ext = targetType === 'image/png' ? 'png' : 'jpg';
+    downloadLink.href = compressedURL;
+    downloadLink.download = `${baseName}-compressed.${ext}`;
+    downloadLink.removeAttribute('disabled');
+}
+
+function processSelectedFile(f) {
+    if (!f) return;
+    if (!/^image\/(png|jpeg)$/.test(f.type)) {
+        alert('Please select a JPG or PNG image.');
+        if (fileInput) fileInput.value = '';
+        return;
+    }
+    originalFile = f;
+    loadImage(f).then(img => {
+        originalImg = img;
+        // show original preview
+        const url = URL.createObjectURL(f);
+        showImageIn(origPreview, url, img.naturalWidth, img.naturalHeight);
+
+        // set initial width/height inputs to the original image size
+        maxWidthEl.value = String(img.naturalWidth);
+        maxHeightEl.value = String(img.naturalHeight);
+        // Fill initial info
+        infoOriginal.textContent = `Original: ${img.naturalWidth}×${img.naturalHeight}, ${bytesToNice(f.size)}`;
+        infoCompressed.textContent = 'Compressed: —';
+        infoSavings.textContent = 'Savings: —';
+        // Enable actions
+        compressBtn.disabled = false;
+        // Auto-run compression once
+        compress();
+    }).catch(() => {
+        alert('Failed to load image.');
+    });
+}
+
+function onFileChange() {
+    const f = fileInput.files && fileInput.files[0];
+    processSelectedFile(f);
+}
+
+function onQualityInput() {
+    const v = Math.min(100, Math.max(1, parseInt(qualityRange.value, 10) || 80));
+    qualityValue.value = v + '%';
+}
+
+function debounce(fn, ms) {
+    let t;
+    return function () {
+        clearTimeout(t);
+        const args = arguments;
+        const ctx = this;
+        t = setTimeout(() => fn.apply(ctx, args), ms);
+    };
+}
+
+function syncResizableFromInputs() {
+    if (!resizableComp || !originalImg) return;
+    const cr = resizableComp.getBoundingClientRect();
+
+    let w = parseInt(maxWidthEl.value, 10);
+    let h = parseInt(maxHeightEl.value, 10);
+    const hasW = Number.isFinite(w) && w > 0;
+    const hasH = Number.isFinite(h) && h > 0;
+    const keepAspect = !!(keepAspectEl && keepAspectEl.checked);
+
+    if (keepAspect && originalImg) {
+        const aspect = originalImg.naturalWidth / originalImg.naturalHeight;
+        if (hasW && !hasH) h = Math.round(w / aspect);
+        else if (hasH && !hasW) w = Math.round(h * aspect);
+        else if (!hasW && !hasH) {
+            w = originalImg.naturalWidth;
+            h = originalImg.naturalHeight;
+        } else {
+            // both provided: ensure consistency
+            h = Math.round(w / aspect);
+        }
+    } else {
+        // no-aspect: respect only what the user set
+        if (!hasW) w = Math.max(1, Math.round(cr.width));
+        if (!hasH) h = Math.max(1, Math.round(cr.height));
+    }
+
+    isProgrammaticResize = true;
+    resizableComp.style.width = w + 'px';
+    resizableComp.style.height = h + 'px';
+    // mirror to original preview size
+    if (resizableOrig) {
+        resizableOrig.style.width = w + 'px';
+        resizableOrig.style.height = h + 'px';
+    }
+    lastBoxW = w;
+    lastBoxH = h;
+    // release the guard after layout flush
+    requestAnimationFrame(() => {
+        isProgrammaticResize = false;
+    });
+}
+
+function updateResizableAspect() {
+    if (!resizableComp) {
+        return;
+    }
+    if (!originalImg) {
+        resizableComp.style.aspectRatio = '';
+        return;
+    }
+    const keep = keepAspectEl ? !!keepAspectEl.checked : true;
+    resizableComp.style.aspectRatio = keep ? (originalImg.naturalWidth + ' / ' + originalImg.naturalHeight) : '';
+}
+
+const debouncedCompress = debounce(() => {
+    if (originalFile) compress();
+}, 200);
+
+// Events
+if (fileInput) fileInput.addEventListener('change', onFileChange);
+
+// Use Original preview as uploader (click and drag-drop)
+if (origPreview) {
+    origPreview.addEventListener('click', () => {
+        if (fileInput) fileInput.click();
+    });
+    origPreview.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            if (fileInput) fileInput.click();
+        }
+    });
+    const setDrag = (on) => {
+        if (on) origPreview.classList.add('dragover'); else origPreview.classList.remove('dragover');
+    };
+    ['dragenter','dragover'].forEach(type => {
+        origPreview.addEventListener(type, (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setDrag(true);
+        });
+    });
+    ['dragleave','dragend','drop'].forEach(type => {
+        origPreview.addEventListener(type, (e) => {
+            if (type !== 'drop') setDrag(false);
+        });
+    });
+    origPreview.addEventListener('drop', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setDrag(false);
+        const files = e.dataTransfer && e.dataTransfer.files;
+        if (!files || !files.length) return;
+        const f = files[0];
+        processSelectedFile(f);
+    });
+}
+
+qualityRange.addEventListener('input', () => {
     onQualityInput();
-})();
+});
+qualityRange.addEventListener('change', debounce(() => {
+    if (originalFile) compress();
+}, 150));
+formatSel.addEventListener('change', () => {
+    if (originalFile) compress();
+});
+const onDimInput = () => {
+    syncResizableFromInputs();
+    debouncedCompress();
+};
+maxWidthEl.addEventListener('input', onDimInput);
+maxWidthEl.addEventListener('change', onDimInput);
+maxHeightEl.addEventListener('input', onDimInput);
+maxHeightEl.addEventListener('change', onDimInput);
+if (keepAspectEl) {
+    keepAspectEl.addEventListener('change', () => {
+        updateResizableAspect();
+        syncResizableFromInputs();
+        debouncedCompress();
+    });
+}
+compressBtn.addEventListener('click', () => {
+    compress();
+});
+
+// Initialize
+onQualityInput();

--- a/tools/image-compressor/script.js
+++ b/tools/image-compressor/script.js
@@ -14,6 +14,24 @@ const infoCompressed = document.getElementById('infoCompressed');
 const infoSavings = document.getElementById('infoSavings');
 const transparencyNote = document.getElementById('transparencyNote');
 
+// Accessibility-friendly toggle for the download link state
+function setDownloadEnabled(enabled) {
+    if (!downloadLink) return;
+    if (enabled) {
+        downloadLink.removeAttribute('aria-disabled');
+        downloadLink.removeAttribute('tabindex');
+        downloadLink.classList.remove('is-disabled');
+        downloadLink.removeAttribute('disabled');
+    } else {
+        downloadLink.setAttribute('aria-disabled', 'true');
+        downloadLink.setAttribute('tabindex', '-1');
+        downloadLink.classList.add('is-disabled');
+        downloadLink.setAttribute('disabled', '');
+        downloadLink.removeAttribute('href');
+        downloadLink.removeAttribute('download');
+    }
+}
+
 let originalFile = null;
 let originalImg = null;
 let compressedBlob = null;
@@ -277,7 +295,7 @@ async function compress() {
     const ext = targetType === 'image/png' ? 'png' : 'jpg';
     downloadLink.href = compressedURL;
     downloadLink.download = `${baseName}-compressed.${ext}`;
-    downloadLink.removeAttribute('disabled');
+    setDownloadEnabled(true);
 }
 
 function processSelectedFile(f) {
@@ -392,6 +410,16 @@ const debouncedCompress = debounce(() => {
 // Events
 if (fileInput) fileInput.addEventListener('change', onFileChange);
 
+// Prevent interaction when download link is disabled (accessibility)
+if (downloadLink) {
+    downloadLink.addEventListener('click', (e) => {
+        if (downloadLink.hasAttribute('disabled') || downloadLink.getAttribute('aria-disabled') === 'true') {
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    });
+}
+
 // Use Original preview as uploader (click and drag-drop)
 if (origPreview) {
     origPreview.addEventListener('click', () => {
@@ -459,3 +487,4 @@ compressBtn.addEventListener('click', () => {
 
 // Initialize
 onQualityInput();
+setDownloadEnabled(false);


### PR DESCRIPTION
## ✨ Description

Adds a client-side Image Compressor/Optimizer Tool that lets users upload a JPG/PNG, adjust settings, and download a compressed version directly in the browser.

- Output format: PNG or JPG
- Adjustable quality via slider
- Configurable dimensions (max width/height) with keep aspect ratio option

Fixes #201 

## 📸 Screenshot (if applicable)
<img width="1717" height="1260" alt="image_compressor" src="https://github.com/user-attachments/assets/f8ea5f8e-9dc1-4ce1-8b5a-a06850e34db7" />

<details>
<summary>▶ Show demo GIF</summary>

![2025-10-04_20h55_06](https://github.com/user-attachments/assets/ebe0581f-017b-4231-9a39-315b1108f1e1)
</details>


## ✅ Checklist
- [x] My code follows the contribution guidelines of this project.
- [x] I have added a card for my new tool in the main `index.html`.
- [x] My changes work perfectly on the live demo.