### PR TITLE
Add File Encryptor & Decryptor

### DIFF
--- a/index.html
+++ b/index.html
@@ -1110,7 +1110,28 @@
                     <div class="tool-arrow">
                         <i class="fas fa-arrow-right"></i>
                     </div>
-                  </a>
+                </a>
+
+                <!-- File Encryptor (AES-GCM) -->
+                <a href="tools/file-encryptor/index.html" class="tool-card" data-category="utility">
+                    <div class="tool-icon">
+                        <i class="fas fa-lock"></i>
+                    </div>
+                    <div class="tool-content">
+                        <h3 class="tool-title">File Encryptor</h3>
+                        <p class="tool-description">
+                            Encrypt and decrypt files locally using AES-GCM with a password. Nothing is uploaded.
+                        </p>
+                        <div class="tool-tags">
+                            <span class="tag">Security</span>
+                            <span class="tag">AES-GCM</span>
+                            <span class="tag">PBKDF2</span>
+                        </div>
+                    </div>
+                    <div class="tool-arrow">
+                        <i class="fas fa-arrow-right"></i>
+                    </div>
+                </a>
 
                 <!-- Color Contrast Checker -->
                 <a href="tools/color-contrast-checker/index.html" class="tool-card" data-category="utility">

--- a/tools/file-encryptor/index.html
+++ b/tools/file-encryptor/index.html
@@ -72,7 +72,11 @@
 
     .field{ margin:12px 0 }
     .field label{ display:block; font-size:.9rem; color:var(--muted); margin-bottom:6px }
-    .field input[type="password"], .field input[type="text"]{ width:100%; padding:12px 14px; border-radius:10px; background:#0f141a; color:var(--text); border:1px solid var(--border); outline:none }
+    .field input[type="password"], .field input[type="text"], .field input[type="number"], .field select{ width:100%; padding:12px 14px; border-radius:10px; background:#0f141a; color:var(--text); border:1px solid var(--border); outline:none }
+        .field select{ appearance:none; background-image: linear-gradient(45deg, transparent 50%, var(--muted) 50%), linear-gradient(135deg, var(--muted) 50%, transparent 50%); background-position: calc(100% - 20px) calc(1em + 2px), calc(100% - 15px) calc(1em + 2px); background-size: 5px 5px, 5px 5px; background-repeat: no-repeat }
+        .field input[type="number"]{ -moz-appearance: textfield }
+        .field input[type="number"]::-webkit-outer-spin-button,
+        .field input[type="number"]::-webkit-inner-spin-button{ -webkit-appearance: none; margin: 0 }
     .file-drop{ border:2px dashed #2d3744; border-radius:12px; padding:24px; text-align:center; background:#0f141a }
     .file-drop.drag{ border-color: var(--secondary); background: rgba(255,159,28,.06) }
     /* Styled link inside file drop to match design */
@@ -169,6 +173,30 @@
           </div>
         </section>
       </div>
+
+      <section class="panel" id="advancedPanel" style="margin-top:18px;">
+        <details>
+          <summary style="cursor:pointer; font-weight:600;">Advanced Options (optional)</summary>
+          <div class="field" style="margin-top:12px;">
+            <label for="advIterations">PBKDF2 Iterations</label>
+            <input type="number" id="advIterations" min="10000" step="1000" value="250000" />
+            <div class="small">Higher = slower but stronger. Recommended 200k–600k depending on device.</div>
+          </div>
+          <div class="field">
+            <label for="advKeyLen">AES-GCM Key Length (bits)</label>
+            <select id="advKeyLen">
+              <option value="128">128</option>
+              <option value="192">192</option>
+              <option value="256" selected>256</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="advIvLen">GCM IV Length (bytes)</label>
+            <input type="number" id="advIvLen" min="12" max="32" step="1" value="12" />
+            <div class="small">12 bytes (96 bits) is recommended for AES-GCM.</div>
+          </div>
+        </details>
+      </section>
 
       <div class="footer">All operations happen locally in your browser via Web Crypto API. Nothing is uploaded.</div>
     </div>

--- a/tools/file-encryptor/index.html
+++ b/tools/file-encryptor/index.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>File Encryptor (AES-GCM) - DevToolkit</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --primary: #ff6b35;
+      --secondary: #ff9f1c;
+      --bg1: #0d1117;
+      --bg2: #161b22;
+      --bg3: #1f2630;
+      --text: #f0f6fc;
+      --muted: #9aa4b2;
+      --border: #2d3440;
+      --success: #2ea043;
+      --error: #f85149;
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 10px 30px rgba(0,0,0,.35);
+      --grad: linear-gradient(135deg, var(--primary), var(--secondary));
+    }
+    *{box-sizing:border-box}
+    body{
+      margin:0; font-family: "Poppins", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      background: radial-gradient(1000px 600px at 10% 10%, rgba(255,107,53,.08), transparent),
+                  radial-gradient(1000px 600px at 90% 90%, rgba(255,159,28,.06), transparent),
+                  linear-gradient(180deg, var(--bg1), var(--bg2));
+      color:var(--text);
+      min-height:100vh;
+    }
+    .container{max-width:1100px;margin:0 auto;padding:64px 32px 32px}
+    header{ text-align:center; margin:20px 0 28px }
+    h1{font-size:2.2rem; margin:0 0 8px; font-weight:700; background:var(--grad); -webkit-background-clip:text; -webkit-text-fill-color:transparent}
+    p.subtitle{color:var(--muted)}
+
+    /* Back button */
+    .back-button {
+      position: fixed;
+      top: 2rem;
+      left: 2rem;
+      z-index: 1000;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 16px;
+      background: var(--bg2);
+      color: var(--text);
+      text-decoration: none;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      transition: all .2s ease;
+      backdrop-filter: blur(12px);
+      box-shadow: var(--shadow);
+    }
+    .back-button:hover {
+      background: var(--primary);
+      color: #ffffff;
+      transform: translateY(-2px);
+    }
+
+    .card{ background: linear-gradient(180deg, var(--bg2), var(--bg3)); border:1px solid var(--border); border-radius:var(--radius); box-shadow:var(--shadow); padding:24px }
+
+    .grid{ display:grid; grid-template-columns: 1fr 1fr; gap:18px }
+    @media (max-width: 900px){ .grid{ grid-template-columns: 1fr } }
+
+    .panel{ background: #11161d; border:1px solid var(--border); border-radius:var(--radius-sm); padding:18px }
+    .panel h2{ font-size:1.1rem; margin:0 0 12px }
+
+    .field{ margin:12px 0 }
+    .field label{ display:block; font-size:.9rem; color:var(--muted); margin-bottom:6px }
+    .field input[type="password"], .field input[type="text"]{ width:100%; padding:12px 14px; border-radius:10px; background:#0f141a; color:var(--text); border:1px solid var(--border); outline:none }
+    .file-drop{ border:2px dashed #2d3744; border-radius:12px; padding:24px; text-align:center; background:#0f141a }
+    .file-drop.drag{ border-color: var(--secondary); background: rgba(255,159,28,.06) }
+    /* Styled link inside file drop to match design */
+    .file-drop a{ color: var(--secondary); text-decoration: none; font-weight: 600; border-bottom: 1px dashed var(--secondary); padding-bottom: 1px; cursor: pointer }
+    .file-drop a:hover{ color: var(--primary); border-bottom-color: var(--primary) }
+
+    .actions{ display:flex; gap:12px; flex-wrap:wrap; margin-top:14px }
+    .decrypt-actions { margin-top: 32px;}
+    button{ appearance:none; border:none; padding:12px 16px; border-radius:10px; font-weight:600; cursor:pointer; transition:.2s transform, .2s opacity }
+    button.primary{ background:var(--grad); color:#06121a }
+    button.secondary{ background:#11161d; border:1px solid var(--border); color:var(--text) }
+    button:disabled{ opacity:.6; cursor:not-allowed }
+
+    .status{ margin-top:12px; font-size:.95rem; color:var(--muted) }
+    .status.success{ color:var(--success) }
+    .status.error{ color:var(--error) }
+
+    .result{ margin-top:14px; display:none }
+    .result a{ color:#06121a; text-decoration:none; background:var(--grad); padding:10px 14px; border-radius:10px; display:inline-flex; align-items:center; gap:8px; font-weight:600 }
+    .small{ font-size:.85rem; color:var(--muted) }
+    .note{ margin-top:10px; color:var(--muted); font-size:.9rem }
+    .footer{ margin-top:28px; text-align:center; color:var(--muted); font-size:.9rem }
+    .inline{ display:flex; gap:10px; align-items:center }
+  </style>
+</head>
+<body>
+  <!-- Back Button -->
+  <a href="../../index.html" class="back-button"><i class="fas fa-arrow-left"></i> Back to Tools</a>
+  <div class="container">
+    <header>
+      <h1>File Encryptor (AES-GCM)</h1>
+      <p class="subtitle">Encrypt and decrypt files in your browser. Password-based encryption using Web Crypto (AES-GCM + PBKDF2). No uploads.</p>
+    </header>
+
+    <div class="card">
+      <div class="grid">
+        <section class="panel" id="encryptPanel">
+          <h2><i class="fa-solid fa-lock"></i> Encrypt</h2>
+          <div class="field">
+            <label>Choose file to encrypt</label>
+            <div class="file-drop" id="encDrop">
+              <input type="file" id="encFile" style="display:none" />
+              <div>
+                <p><i class="fa-regular fa-file"></i> Drag & drop a file here or <a href="#" id="encBrowse">browse</a></p>
+                <p class="small" id="encFileName">No file selected</p>
+              </div>
+            </div>
+          </div>
+          <div class="field">
+            <label>Password</label>
+            <div class="inline">
+              <input type="password" id="encPassword" placeholder="Enter a strong password" />
+              <button class="secondary" id="toggleEncPass" title="Show/Hide"><i class="fa-regular fa-eye"></i></button>
+            </div>
+            <div class="small" id="strength">Tip: longer is stronger. Use a passphrase.</div>
+          </div>
+          <div class="actions">
+            <button class="primary" id="encryptBtn"><i class="fa-solid fa-lock"></i> Encrypt</button>
+            <button class="secondary" id="clearEnc">Clear</button>
+          </div>
+          <div class="status" id="encStatus"></div>
+          <div class="result" id="encResult">
+            <a id="downloadEnc" download><i class="fa-solid fa-download"></i> Download encrypted file</a>
+            <div class="note">Keep the .enc file and your password safe. You'll need both to decrypt.</div>
+          </div>
+        </section>
+
+        <section class="panel" id="decryptPanel">
+          <h2><i class="fa-solid fa-lock-open"></i> Decrypt</h2>
+          <div class="field">
+            <label>Choose encrypted file (.enc)</label>
+            <div class="file-drop" id="decDrop">
+              <input type="file" id="decFile" accept="application/json,.enc,.bin,.txt" style="display:none" />
+              <div>
+                <p><i class="fa-regular fa-file-lines"></i> Drag & drop the encrypted file here or <a href="#" id="decBrowse">browse</a></p>
+                <p class="small" id="decFileName">No file selected</p>
+              </div>
+            </div>
+          </div>
+          <div class="field">
+            <label>Password</label>
+            <div class="inline">
+              <input type="password" id="decPassword" placeholder="Enter the same password used for encryption" />
+              <button class="secondary" id="toggleDecPass" title="Show/Hide"><i class="fa-regular fa-eye"></i></button>
+            </div>
+          </div>
+          <div class="actions decrypt-actions">
+            <button class="primary" id="decryptBtn"><i class="fa-solid fa-unlock-keyhole"></i> Decrypt</button>
+            <button class="secondary" id="clearDec">Clear</button>
+          </div>
+          <div class="status" id="decStatus"></div>
+          <div class="result" id="decResult">
+            <a id="downloadDec" download><i class="fa-solid fa-download"></i> Download decrypted file</a>
+          </div>
+        </section>
+      </div>
+
+      <div class="footer">All operations happen locally in your browser via Web Crypto API. Nothing is uploaded.</div>
+    </div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/tools/file-encryptor/script.js
+++ b/tools/file-encryptor/script.js
@@ -1,0 +1,254 @@
+// File Encryptor (AES-GCM) - Web Crypto API
+// Uses PBKDF2 to derive a key from password, AES-GCM for encryption
+// Output format: JSON with base64 fields
+
+(() => {
+  const encFileInput = document.getElementById('encFile');
+  const encDrop = document.getElementById('encDrop');
+  const encBrowse = document.getElementById('encBrowse');
+  const encFileName = document.getElementById('encFileName');
+  const encPassword = document.getElementById('encPassword');
+  const toggleEncPass = document.getElementById('toggleEncPass');
+  const encryptBtn = document.getElementById('encryptBtn');
+  const clearEnc = document.getElementById('clearEnc');
+  const encStatus = document.getElementById('encStatus');
+  const encResult = document.getElementById('encResult');
+  const downloadEnc = document.getElementById('downloadEnc');
+
+  const decFileInput = document.getElementById('decFile');
+  const decDrop = document.getElementById('decDrop');
+  const decBrowse = document.getElementById('decBrowse');
+  const decFileName = document.getElementById('decFileName');
+  const decPassword = document.getElementById('decPassword');
+  const toggleDecPass = document.getElementById('toggleDecPass');
+  const decryptBtn = document.getElementById('decryptBtn');
+  const clearDec = document.getElementById('clearDec');
+  const decStatus = document.getElementById('decStatus');
+  const decResult = document.getElementById('decResult');
+  const downloadDec = document.getElementById('downloadDec');
+
+  const PBKDF2_ITERATIONS = 250000; // ~250k iterations for decent security; adjust for performance
+  const KEY_LENGTH = 256; // bits
+  const GCM_IV_LENGTH = 12; // bytes (96 bits) recommended
+
+  function toBase64(bytes) {
+    return btoa(String.fromCharCode(...new Uint8Array(bytes)));
+  }
+  function fromBase64(b64) {
+    const bin = atob(b64);
+    const arr = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+    return arr.buffer;
+  }
+
+  async function deriveKey(password, salt, iterations = PBKDF2_ITERATIONS) {
+    const enc = new TextEncoder();
+    const keyMaterial = await crypto.subtle.importKey(
+      'raw',
+      enc.encode(password),
+      { name: 'PBKDF2' },
+      false,
+      ['deriveKey']
+    );
+    return crypto.subtle.deriveKey(
+      {
+        name: 'PBKDF2',
+        salt,
+        iterations,
+        hash: 'SHA-256'
+      },
+      keyMaterial,
+      { name: 'AES-GCM', length: KEY_LENGTH },
+      false,
+      ['encrypt', 'decrypt']
+    );
+  }
+
+  async function encryptFile(file, password) {
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const iv = crypto.getRandomValues(new Uint8Array(GCM_IV_LENGTH));
+    const key = await deriveKey(password, salt);
+    const data = new Uint8Array(await file.arrayBuffer());
+
+    const cipherBuf = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
+
+    const payload = {
+      v: 1,
+      algo: 'AES-GCM',
+      kdf: 'PBKDF2-SHA256',
+      iterations: PBKDF2_ITERATIONS,
+      salt: toBase64(salt),
+      iv: toBase64(iv),
+      mime: file.type || 'application/octet-stream',
+      name: file.name || 'file',
+      ciphertext: toBase64(new Uint8Array(cipherBuf))
+    };
+    const json = JSON.stringify(payload);
+    const blob = new Blob([json], { type: 'application/json' });
+    const outName = file.name + '.enc';
+    return { blob, filename: outName };
+  }
+
+  async function decryptFile(file, password) {
+    // Read JSON
+    let text;
+    if (file.type.startsWith('application/') || file.type.startsWith('text/')) {
+      text = await file.text();
+    } else {
+      // Still try to parse as text
+      text = await file.text();
+    }
+
+    let payload;
+    try {
+      payload = JSON.parse(text);
+    } catch (e) {
+      throw new Error('Invalid encrypted file format (not JSON)');
+    }
+
+    if (!payload || payload.v !== 1 || payload.algo !== 'AES-GCM') {
+      throw new Error('Unsupported encrypted file format');
+    }
+
+    const salt = new Uint8Array(fromBase64(payload.salt));
+    const iv = new Uint8Array(fromBase64(payload.iv));
+    const ciphertext = new Uint8Array(fromBase64(payload.ciphertext));
+    const iterations = Number(payload.iterations) || PBKDF2_ITERATIONS;
+
+    const key = await deriveKey(password, salt, iterations);
+    let plainBuf;
+    try {
+      plainBuf = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+    } catch (e) {
+      throw new Error('Decryption failed. Wrong password or corrupted file.');
+    }
+
+    const blob = new Blob([plainBuf], { type: payload.mime || 'application/octet-stream' });
+    const outName = payload.name || 'decrypted.bin';
+    return { blob, filename: outName };
+  }
+
+  // UI helpers
+  function setupDrop(dropEl, inputEl, nameEl) {
+    ['dragenter', 'dragover'].forEach(evt => dropEl.addEventListener(evt, e => {
+      e.preventDefault(); e.stopPropagation(); dropEl.classList.add('drag');
+    }));
+    ['dragleave', 'drop'].forEach(evt => dropEl.addEventListener(evt, e => {
+      e.preventDefault(); e.stopPropagation(); dropEl.classList.remove('drag');
+    }));
+    dropEl.addEventListener('drop', e => {
+      const files = e.dataTransfer?.files;
+      if (files && files.length) {
+        inputEl.files = files;
+        nameEl.textContent = files[0].name + ` (${(files[0].size/1024).toFixed(1)} KB)`;
+      }
+    });
+    dropEl.addEventListener('click', () => inputEl.click());
+  }
+
+  function setStatus(el, msg, type) {
+    el.textContent = msg || '';
+    el.classList.remove('success', 'error');
+    if (type) el.classList.add(type);
+  }
+
+  function togglePassword(buttonEl, inputEl) {
+    if (inputEl.type === 'password') {
+      inputEl.type = 'text';
+      buttonEl.innerHTML = '<i class="fa-regular fa-eye-slash"></i>';
+    } else {
+      inputEl.type = 'password';
+      buttonEl.innerHTML = '<i class="fa-regular fa-eye"></i>';
+    }
+  }
+
+  function blobDownloadLink(blob, filename, anchor) {
+    const url = URL.createObjectURL(blob);
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.addEventListener('click', () => {
+      // revoke shortly after click
+      setTimeout(() => URL.revokeObjectURL(url), 5000);
+    }, { once: true });
+  }
+
+  // Wire up Encrypt panel
+  setupDrop(encDrop, encFileInput, encFileName);
+  encBrowse.addEventListener('click', (e) => { e.preventDefault(); encFileInput.click(); });
+  encFileInput.addEventListener('change', () => {
+    const f = encFileInput.files?.[0];
+    encFileName.textContent = f ? `${f.name} (${(f.size/1024).toFixed(1)} KB)` : 'No file selected';
+  });
+
+  toggleEncPass.addEventListener('click', () => togglePassword(toggleEncPass, encPassword));
+
+  encryptBtn.addEventListener('click', async () => {
+    encResult.style.display = 'none';
+    const file = encFileInput.files?.[0];
+    if (!file) { setStatus(encStatus, 'Please select a file to encrypt.', 'error'); return; }
+    const pwd = encPassword.value || '';
+    if (pwd.length < 6) { setStatus(encStatus, 'Please enter a longer password (at least 6 characters).', 'error'); return; }
+
+    encryptBtn.disabled = true; clearEnc.disabled = true;
+    setStatus(encStatus, 'Encrypting... this may take a moment for large files.');
+    try {
+      const { blob, filename } = await encryptFile(file, pwd);
+      blobDownloadLink(blob, filename, downloadEnc);
+      encResult.style.display = 'block';
+      setStatus(encStatus, 'Encryption successful!', 'success');
+    } catch (e) {
+      console.error(e);
+      setStatus(encStatus, e.message || 'Encryption failed.', 'error');
+    } finally {
+      encryptBtn.disabled = false; clearEnc.disabled = false;
+    }
+  });
+
+  clearEnc.addEventListener('click', () => {
+    encFileInput.value = '';
+    encPassword.value = '';
+    encFileName.textContent = 'No file selected';
+    encResult.style.display = 'none';
+    setStatus(encStatus, '');
+  });
+
+  // Wire up Decrypt panel
+  setupDrop(decDrop, decFileInput, decFileName);
+  decBrowse.addEventListener('click', (e) => { e.preventDefault(); decFileInput.click(); });
+  decFileInput.addEventListener('change', () => {
+    const f = decFileInput.files?.[0];
+    decFileName.textContent = f ? `${f.name} (${(f.size/1024).toFixed(1)} KB)` : 'No file selected';
+  });
+
+  toggleDecPass.addEventListener('click', () => togglePassword(toggleDecPass, decPassword));
+
+  decryptBtn.addEventListener('click', async () => {
+    decResult.style.display = 'none';
+    const file = decFileInput.files?.[0];
+    if (!file) { setStatus(decStatus, 'Please select an encrypted file (.enc).', 'error'); return; }
+    const pwd = decPassword.value || '';
+    if (!pwd) { setStatus(decStatus, 'Please enter the password.', 'error'); return; }
+
+    decryptBtn.disabled = true; clearDec.disabled = true;
+    setStatus(decStatus, 'Decrypting...');
+    try {
+      const { blob, filename } = await decryptFile(file, pwd);
+      blobDownloadLink(blob, filename, downloadDec);
+      decResult.style.display = 'block';
+      setStatus(decStatus, 'Decryption successful!', 'success');
+    } catch (e) {
+      console.error(e);
+      setStatus(decStatus, e.message || 'Decryption failed.', 'error');
+    } finally {
+      decryptBtn.disabled = false; clearDec.disabled = false;
+    }
+  });
+
+  clearDec.addEventListener('click', () => {
+    decFileInput.value = '';
+    decPassword.value = '';
+    decFileName.textContent = 'No file selected';
+    decResult.style.display = 'none';
+    setStatus(decStatus, '');
+  });
+})();

--- a/tools/file-encryptor/script.js
+++ b/tools/file-encryptor/script.js
@@ -1,75 +1,71 @@
-// File Encryptor (AES-GCM) - Web Crypto API
-// Uses PBKDF2 to derive a key from password, AES-GCM for encryption
-// Output format: JSON with base64 fields
+const encFileInput = document.getElementById('encFile');
+const encDrop = document.getElementById('encDrop');
+const encBrowse = document.getElementById('encBrowse');
+const encFileName = document.getElementById('encFileName');
+const encPassword = document.getElementById('encPassword');
+const toggleEncPass = document.getElementById('toggleEncPass');
+const encryptBtn = document.getElementById('encryptBtn');
+const clearEnc = document.getElementById('clearEnc');
+const encStatus = document.getElementById('encStatus');
+const encResult = document.getElementById('encResult');
+const downloadEnc = document.getElementById('downloadEnc');
 
-(() => {
-  const encFileInput = document.getElementById('encFile');
-  const encDrop = document.getElementById('encDrop');
-  const encBrowse = document.getElementById('encBrowse');
-  const encFileName = document.getElementById('encFileName');
-  const encPassword = document.getElementById('encPassword');
-  const toggleEncPass = document.getElementById('toggleEncPass');
-  const encryptBtn = document.getElementById('encryptBtn');
-  const clearEnc = document.getElementById('clearEnc');
-  const encStatus = document.getElementById('encStatus');
-  const encResult = document.getElementById('encResult');
-  const downloadEnc = document.getElementById('downloadEnc');
+const decFileInput = document.getElementById('decFile');
+const decDrop = document.getElementById('decDrop');
+const decBrowse = document.getElementById('decBrowse');
+const decFileName = document.getElementById('decFileName');
+const decPassword = document.getElementById('decPassword');
+const toggleDecPass = document.getElementById('toggleDecPass');
+const decryptBtn = document.getElementById('decryptBtn');
+const clearDec = document.getElementById('clearDec');
+const decStatus = document.getElementById('decStatus');
+const decResult = document.getElementById('decResult');
+const downloadDec = document.getElementById('downloadDec');
 
-  const decFileInput = document.getElementById('decFile');
-  const decDrop = document.getElementById('decDrop');
-  const decBrowse = document.getElementById('decBrowse');
-  const decFileName = document.getElementById('decFileName');
-  const decPassword = document.getElementById('decPassword');
-  const toggleDecPass = document.getElementById('toggleDecPass');
-  const decryptBtn = document.getElementById('decryptBtn');
-  const clearDec = document.getElementById('clearDec');
-  const decStatus = document.getElementById('decStatus');
-  const decResult = document.getElementById('decResult');
-  const downloadDec = document.getElementById('downloadDec');
+// Advanced options (hidden menu)
+const advIterationsEl = document.getElementById('advIterations');
+const advKeyLenEl = document.getElementById('advKeyLen');
+const advIvLenEl = document.getElementById('advIvLen');
 
-  // Advanced options (hidden menu)
-  const advIterationsEl = document.getElementById('advIterations');
-  const advKeyLenEl = document.getElementById('advKeyLen');
-  const advIvLenEl = document.getElementById('advIvLen');
+const PBKDF2_ITERATIONS = 250000; // default iterations
+const KEY_LENGTH = 256; // bits (default)
+const GCM_IV_LENGTH = 12; // bytes (96 bits) recommended (default)
 
-  const PBKDF2_ITERATIONS = 250000; // default iterations
-  const KEY_LENGTH = 256; // bits (default)
-  const GCM_IV_LENGTH = 12; // bytes (96 bits) recommended (default)
-
-  function toBase64(bytes) {
+function toBase64(bytes) {
     return btoa(String.fromCharCode(...new Uint8Array(bytes)));
-  }
-  function fromBase64(b64) {
+}
+
+function fromBase64(b64) {
     const bin = atob(b64);
     const arr = new Uint8Array(bin.length);
     for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
     return arr.buffer;
-  }
+}
 
-  async function deriveKey(password, salt, iterations = PBKDF2_ITERATIONS, keyLength = KEY_LENGTH) {
+async function deriveKey(password, salt, iterations = PBKDF2_ITERATIONS, keyLength = KEY_LENGTH) {
     const enc = new TextEncoder();
     const keyMaterial = await crypto.subtle.importKey(
-      'raw',
-      enc.encode(password),
-      { name: 'PBKDF2' },
-      false,
-      ['deriveKey']
+        'raw',
+        enc.encode(password),
+        {name: 'PBKDF2'},
+        false,
+        ['deriveKey']
     );
     return crypto.subtle.deriveKey(
-      {
-        name: 'PBKDF2',
-        salt,
-        iterations,
-        hash: 'SHA-256'
-      },
-      keyMaterial,
-      { name: 'AES-GCM', length: keyLength },
-      false,
-      ['encrypt', 'decrypt']
+        {
+            name: 'PBKDF2',
+            salt,
+            iterations,
+            hash: 'SHA-256'
+        },
+        keyMaterial,
+        {name: 'AES-GCM', length: keyLength},
+        false,
+        ['encrypt', 'decrypt']
     );
-  }
+}
 
-  async function encryptFile(file, password, opts = {}) {
+async function encryptFile(file, password, opts = {}) {
     const iterations = Number(opts.iterations) || PBKDF2_ITERATIONS;
     const keyLength = Number(opts.keyLength) || KEY_LENGTH;
     const ivLength = Number(opts.ivLength) || GCM_IV_LENGTH;
@@ -79,46 +75,46 @@
     const key = await deriveKey(password, salt, iterations, keyLength);
     const data = new Uint8Array(await file.arrayBuffer());
 
-    const cipherBuf = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
+    const cipherBuf = await crypto.subtle.encrypt({name: 'AES-GCM', iv}, key, data);
 
     const payload = {
-      v: 1,
-      algo: 'AES-GCM',
-      kdf: 'PBKDF2-SHA256',
-      iterations,
-      keyLength,
-      ivLength,
-      salt: toBase64(salt),
-      iv: toBase64(iv),
-      mime: file.type || 'application/octet-stream',
-      name: file.name || 'file',
-      ciphertext: toBase64(new Uint8Array(cipherBuf))
+        v: 1,
+        algo: 'AES-GCM',
+        kdf: 'PBKDF2-SHA256',
+        iterations,
+        keyLength,
+        ivLength,
+        salt: toBase64(salt),
+        iv: toBase64(iv),
+        mime: file.type || 'application/octet-stream',
+        name: file.name || 'file',
+        ciphertext: toBase64(new Uint8Array(cipherBuf))
     };
     const json = JSON.stringify(payload);
-    const blob = new Blob([json], { type: 'application/json' });
+    const blob = new Blob([json], {type: 'application/json'});
     const outName = file.name + '.enc';
-    return { blob, filename: outName };
-  }
+    return {blob, filename: outName};
+}
 
-  async function decryptFile(file, password) {
-    // Read JSON
+async function decryptFile(file, password) {
+// Read JSON
     let text;
     if (file.type.startsWith('application/') || file.type.startsWith('text/')) {
-      text = await file.text();
+        text = await file.text();
     } else {
-      // Still try to parse as text
-      text = await file.text();
+        // Still try to parse as text
+        text = await file.text();
     }
 
     let payload;
     try {
-      payload = JSON.parse(text);
+        payload = JSON.parse(text);
     } catch (e) {
-      throw new Error('Invalid encrypted file format (not JSON)');
+        throw new Error('Invalid encrypted file format (not JSON)');
     }
 
     if (!payload || payload.v !== 1 || payload.algo !== 'AES-GCM') {
-      throw new Error('Unsupported encrypted file format');
+        throw new Error('Unsupported encrypted file format');
     }
 
     const salt = new Uint8Array(fromBase64(payload.salt));
@@ -130,163 +126,190 @@
     const key = await deriveKey(password, salt, iterations, keyLength);
     let plainBuf;
     try {
-      plainBuf = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+        plainBuf = await crypto.subtle.decrypt({name: 'AES-GCM', iv}, key, ciphertext);
     } catch (e) {
-      throw new Error('Decryption failed. Wrong password or corrupted file.');
+        throw new Error('Decryption failed. Wrong password or corrupted file.');
     }
 
-    const blob = new Blob([plainBuf], { type: payload.mime || 'application/octet-stream' });
+    const blob = new Blob([plainBuf], {type: payload.mime || 'application/octet-stream'});
     const outName = payload.name || 'decrypted.bin';
-    return { blob, filename: outName };
-  }
+    return {blob, filename: outName};
+}
 
-  // UI helpers
-  function setupDrop(dropEl, inputEl, nameEl) {
+// UI helpers
+function setupDrop(dropEl, inputEl, nameEl) {
     ['dragenter', 'dragover'].forEach(evt => dropEl.addEventListener(evt, e => {
-      e.preventDefault(); e.stopPropagation(); dropEl.classList.add('drag');
+        e.preventDefault();
+        e.stopPropagation();
+        dropEl.classList.add('drag');
     }));
     ['dragleave', 'drop'].forEach(evt => dropEl.addEventListener(evt, e => {
-      e.preventDefault(); e.stopPropagation(); dropEl.classList.remove('drag');
+        e.preventDefault();
+        e.stopPropagation();
+        dropEl.classList.remove('drag');
     }));
     dropEl.addEventListener('drop', e => {
-      const files = e.dataTransfer?.files;
-      if (files && files.length) {
-        inputEl.files = files;
-        nameEl.textContent = files[0].name + ` (${(files[0].size/1024).toFixed(1)} KB)`;
-      }
+        const files = e.dataTransfer?.files;
+        if (files && files.length) {
+            inputEl.files = files;
+            nameEl.textContent = files[0].name + ` (${(files[0].size / 1024).toFixed(1)} KB)`;
+        }
     });
     dropEl.addEventListener('click', () => inputEl.click());
-  }
+}
 
-  function setStatus(el, msg, type) {
+function setStatus(el, msg, type) {
     el.textContent = msg || '';
     el.classList.remove('success', 'error');
     if (type) el.classList.add(type);
-  }
+}
 
-  function togglePassword(buttonEl, inputEl) {
+function togglePassword(buttonEl, inputEl) {
     if (inputEl.type === 'password') {
-      inputEl.type = 'text';
-      buttonEl.innerHTML = '<i class="fa-regular fa-eye-slash"></i>';
+        inputEl.type = 'text';
+        buttonEl.innerHTML = '<i class="fa-regular fa-eye-slash"></i>';
     } else {
-      inputEl.type = 'password';
-      buttonEl.innerHTML = '<i class="fa-regular fa-eye"></i>';
+        inputEl.type = 'password';
+        buttonEl.innerHTML = '<i class="fa-regular fa-eye"></i>';
     }
-  }
+}
 
-  function blobDownloadLink(blob, filename, anchor) {
+function blobDownloadLink(blob, filename, anchor) {
     const url = URL.createObjectURL(blob);
     anchor.href = url;
     anchor.download = filename;
     anchor.addEventListener('click', () => {
-      // revoke shortly after click
-      setTimeout(() => URL.revokeObjectURL(url), 5000);
-    }, { once: true });
-  }
+        // revoke shortly after click
+        setTimeout(() => URL.revokeObjectURL(url), 5000);
+    }, {once: true});
+}
 
-  function readAdvancedOptions() {
+function readAdvancedOptions() {
     const iterations = advIterationsEl ? Number(advIterationsEl.value) : PBKDF2_ITERATIONS;
     const keyLength = advKeyLenEl ? Number(advKeyLenEl.value) : KEY_LENGTH;
     const ivLength = advIvLenEl ? Number(advIvLenEl.value) : GCM_IV_LENGTH;
 
-    // Validation
+// Validation
     if (!Number.isFinite(iterations) || iterations < 10000) {
-      throw new Error('PBKDF2 iterations must be a number of at least 10,000.');
+        throw new Error('PBKDF2 iterations must be a number of at least 10,000.');
     }
-    if (![128,192,256].includes(keyLength)) {
-      throw new Error('Key length must be 128, 192, or 256 bits.');
+    if (![128, 192, 256].includes(keyLength)) {
+        throw new Error('Key length must be 128, 192, or 256 bits.');
     }
     if (!Number.isFinite(ivLength) || ivLength < 12 || ivLength > 32) {
-      throw new Error('GCM IV length must be between 12 and 32 bytes.');
+        throw new Error('GCM IV length must be between 12 and 32 bytes.');
     }
-    return { iterations: Math.round(iterations), keyLength, ivLength: Math.round(ivLength) };
-  }
+    return {iterations: Math.round(iterations), keyLength, ivLength: Math.round(ivLength)};
+}
 
-  // Wire up Encrypt panel
-  setupDrop(encDrop, encFileInput, encFileName);
-  encBrowse.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); encFileInput.click(); });
-  encFileInput.addEventListener('change', () => {
+// Wire up Encrypt panel
+setupDrop(encDrop, encFileInput, encFileName);
+encBrowse.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    encFileInput.click();
+});
+encFileInput.addEventListener('change', () => {
     const f = encFileInput.files?.[0];
-    encFileName.textContent = f ? `${f.name} (${(f.size/1024).toFixed(1)} KB)` : 'No file selected';
-  });
+    encFileName.textContent = f ? `${f.name} (${(f.size / 1024).toFixed(1)} KB)` : 'No file selected';
+});
 
-  toggleEncPass.addEventListener('click', () => togglePassword(toggleEncPass, encPassword));
+toggleEncPass.addEventListener('click', () => togglePassword(toggleEncPass, encPassword));
 
-  encryptBtn.addEventListener('click', async () => {
+encryptBtn.addEventListener('click', async () => {
     encResult.style.display = 'none';
     const file = encFileInput.files?.[0];
-    if (!file) { setStatus(encStatus, 'Please select a file to encrypt.', 'error'); return; }
+    if (!file) {
+        setStatus(encStatus, 'Please select a file to encrypt.', 'error');
+        return;
+    }
     const pwd = encPassword.value || '';
-    if (pwd.length < 6) { setStatus(encStatus, 'Please enter a longer password (at least 6 characters).', 'error'); return; }
+    if (pwd.length < 6) {
+        setStatus(encStatus, 'Please enter a longer password (at least 6 characters).', 'error');
+        return;
+    }
 
     let opts;
     try {
-      opts = readAdvancedOptions();
+        opts = readAdvancedOptions();
     } catch (e) {
-      setStatus(encStatus, e.message || 'Invalid advanced options.', 'error');
-      return;
+        setStatus(encStatus, e.message || 'Invalid advanced options.', 'error');
+        return;
     }
 
-    encryptBtn.disabled = true; clearEnc.disabled = true;
+    encryptBtn.disabled = true;
+    clearEnc.disabled = true;
     setStatus(encStatus, 'Encrypting... this may take a moment for large files.');
     try {
-      const { blob, filename } = await encryptFile(file, pwd, opts);
-      blobDownloadLink(blob, filename, downloadEnc);
-      encResult.style.display = 'block';
-      setStatus(encStatus, 'Encryption successful!', 'success');
+        const {blob, filename} = await encryptFile(file, pwd, opts);
+        blobDownloadLink(blob, filename, downloadEnc);
+        encResult.style.display = 'block';
+        setStatus(encStatus, 'Encryption successful!', 'success');
     } catch (e) {
-      console.error(e);
-      setStatus(encStatus, e.message || 'Encryption failed.', 'error');
+        console.error(e);
+        setStatus(encStatus, e.message || 'Encryption failed.', 'error');
     } finally {
-      encryptBtn.disabled = false; clearEnc.disabled = false;
+        encryptBtn.disabled = false;
+        clearEnc.disabled = false;
     }
-  });
+});
 
-  clearEnc.addEventListener('click', () => {
+clearEnc.addEventListener('click', () => {
     encFileInput.value = '';
     encPassword.value = '';
     encFileName.textContent = 'No file selected';
     encResult.style.display = 'none';
     setStatus(encStatus, '');
-  });
+});
 
-  // Wire up Decrypt panel
-  setupDrop(decDrop, decFileInput, decFileName);
-  decBrowse.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); decFileInput.click(); });
-  decFileInput.addEventListener('change', () => {
+// Wire up Decrypt panel
+setupDrop(decDrop, decFileInput, decFileName);
+decBrowse.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    decFileInput.click();
+});
+decFileInput.addEventListener('change', () => {
     const f = decFileInput.files?.[0];
-    decFileName.textContent = f ? `${f.name} (${(f.size/1024).toFixed(1)} KB)` : 'No file selected';
-  });
+    decFileName.textContent = f ? `${f.name} (${(f.size / 1024).toFixed(1)} KB)` : 'No file selected';
+});
 
-  toggleDecPass.addEventListener('click', () => togglePassword(toggleDecPass, decPassword));
+toggleDecPass.addEventListener('click', () => togglePassword(toggleDecPass, decPassword));
 
-  decryptBtn.addEventListener('click', async () => {
+decryptBtn.addEventListener('click', async () => {
     decResult.style.display = 'none';
     const file = decFileInput.files?.[0];
-    if (!file) { setStatus(decStatus, 'Please select an encrypted file (.enc).', 'error'); return; }
+    if (!file) {
+        setStatus(decStatus, 'Please select an encrypted file (.enc).', 'error');
+        return;
+    }
     const pwd = decPassword.value || '';
-    if (!pwd) { setStatus(decStatus, 'Please enter the password.', 'error'); return; }
+    if (!pwd) {
+        setStatus(decStatus, 'Please enter the password.', 'error');
+        return;
+    }
 
-    decryptBtn.disabled = true; clearDec.disabled = true;
+    decryptBtn.disabled = true;
+    clearDec.disabled = true;
     setStatus(decStatus, 'Decrypting...');
     try {
-      const { blob, filename } = await decryptFile(file, pwd);
-      blobDownloadLink(blob, filename, downloadDec);
-      decResult.style.display = 'block';
-      setStatus(decStatus, 'Decryption successful!', 'success');
+        const {blob, filename} = await decryptFile(file, pwd);
+        blobDownloadLink(blob, filename, downloadDec);
+        decResult.style.display = 'block';
+        setStatus(decStatus, 'Decryption successful!', 'success');
     } catch (e) {
-      console.error(e);
-      setStatus(decStatus, e.message || 'Decryption failed.', 'error');
+        console.error(e);
+        setStatus(decStatus, e.message || 'Decryption failed.', 'error');
     } finally {
-      decryptBtn.disabled = false; clearDec.disabled = false;
+        decryptBtn.disabled = false;
+        clearDec.disabled = false;
     }
-  });
+});
 
-  clearDec.addEventListener('click', () => {
+clearDec.addEventListener('click', () => {
     decFileInput.value = '';
     decPassword.value = '';
     decFileName.textContent = 'No file selected';
     decResult.style.display = 'none';
     setStatus(decStatus, '');
-  });
-})();
+});

--- a/tools/file-encryptor/script.js
+++ b/tools/file-encryptor/script.js
@@ -27,9 +27,14 @@
   const decResult = document.getElementById('decResult');
   const downloadDec = document.getElementById('downloadDec');
 
-  const PBKDF2_ITERATIONS = 250000; // ~250k iterations for decent security; adjust for performance
-  const KEY_LENGTH = 256; // bits
-  const GCM_IV_LENGTH = 12; // bytes (96 bits) recommended
+  // Advanced options (hidden menu)
+  const advIterationsEl = document.getElementById('advIterations');
+  const advKeyLenEl = document.getElementById('advKeyLen');
+  const advIvLenEl = document.getElementById('advIvLen');
+
+  const PBKDF2_ITERATIONS = 250000; // default iterations
+  const KEY_LENGTH = 256; // bits (default)
+  const GCM_IV_LENGTH = 12; // bytes (96 bits) recommended (default)
 
   function toBase64(bytes) {
     return btoa(String.fromCharCode(...new Uint8Array(bytes)));
@@ -41,7 +46,7 @@
     return arr.buffer;
   }
 
-  async function deriveKey(password, salt, iterations = PBKDF2_ITERATIONS) {
+  async function deriveKey(password, salt, iterations = PBKDF2_ITERATIONS, keyLength = KEY_LENGTH) {
     const enc = new TextEncoder();
     const keyMaterial = await crypto.subtle.importKey(
       'raw',
@@ -58,16 +63,20 @@
         hash: 'SHA-256'
       },
       keyMaterial,
-      { name: 'AES-GCM', length: KEY_LENGTH },
+      { name: 'AES-GCM', length: keyLength },
       false,
       ['encrypt', 'decrypt']
     );
   }
 
-  async function encryptFile(file, password) {
+  async function encryptFile(file, password, opts = {}) {
+    const iterations = Number(opts.iterations) || PBKDF2_ITERATIONS;
+    const keyLength = Number(opts.keyLength) || KEY_LENGTH;
+    const ivLength = Number(opts.ivLength) || GCM_IV_LENGTH;
+
     const salt = crypto.getRandomValues(new Uint8Array(16));
-    const iv = crypto.getRandomValues(new Uint8Array(GCM_IV_LENGTH));
-    const key = await deriveKey(password, salt);
+    const iv = crypto.getRandomValues(new Uint8Array(ivLength));
+    const key = await deriveKey(password, salt, iterations, keyLength);
     const data = new Uint8Array(await file.arrayBuffer());
 
     const cipherBuf = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
@@ -76,7 +85,9 @@
       v: 1,
       algo: 'AES-GCM',
       kdf: 'PBKDF2-SHA256',
-      iterations: PBKDF2_ITERATIONS,
+      iterations,
+      keyLength,
+      ivLength,
       salt: toBase64(salt),
       iv: toBase64(iv),
       mime: file.type || 'application/octet-stream',
@@ -114,8 +125,9 @@
     const iv = new Uint8Array(fromBase64(payload.iv));
     const ciphertext = new Uint8Array(fromBase64(payload.ciphertext));
     const iterations = Number(payload.iterations) || PBKDF2_ITERATIONS;
+    const keyLength = Number(payload.keyLength) || KEY_LENGTH;
 
-    const key = await deriveKey(password, salt, iterations);
+    const key = await deriveKey(password, salt, iterations, keyLength);
     let plainBuf;
     try {
       plainBuf = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
@@ -172,9 +184,27 @@
     }, { once: true });
   }
 
+  function readAdvancedOptions() {
+    const iterations = advIterationsEl ? Number(advIterationsEl.value) : PBKDF2_ITERATIONS;
+    const keyLength = advKeyLenEl ? Number(advKeyLenEl.value) : KEY_LENGTH;
+    const ivLength = advIvLenEl ? Number(advIvLenEl.value) : GCM_IV_LENGTH;
+
+    // Validation
+    if (!Number.isFinite(iterations) || iterations < 10000) {
+      throw new Error('PBKDF2 iterations must be a number of at least 10,000.');
+    }
+    if (![128,192,256].includes(keyLength)) {
+      throw new Error('Key length must be 128, 192, or 256 bits.');
+    }
+    if (!Number.isFinite(ivLength) || ivLength < 12 || ivLength > 32) {
+      throw new Error('GCM IV length must be between 12 and 32 bytes.');
+    }
+    return { iterations: Math.round(iterations), keyLength, ivLength: Math.round(ivLength) };
+  }
+
   // Wire up Encrypt panel
   setupDrop(encDrop, encFileInput, encFileName);
-  encBrowse.addEventListener('click', (e) => { e.preventDefault(); encFileInput.click(); });
+  encBrowse.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); encFileInput.click(); });
   encFileInput.addEventListener('change', () => {
     const f = encFileInput.files?.[0];
     encFileName.textContent = f ? `${f.name} (${(f.size/1024).toFixed(1)} KB)` : 'No file selected';
@@ -189,10 +219,18 @@
     const pwd = encPassword.value || '';
     if (pwd.length < 6) { setStatus(encStatus, 'Please enter a longer password (at least 6 characters).', 'error'); return; }
 
+    let opts;
+    try {
+      opts = readAdvancedOptions();
+    } catch (e) {
+      setStatus(encStatus, e.message || 'Invalid advanced options.', 'error');
+      return;
+    }
+
     encryptBtn.disabled = true; clearEnc.disabled = true;
     setStatus(encStatus, 'Encrypting... this may take a moment for large files.');
     try {
-      const { blob, filename } = await encryptFile(file, pwd);
+      const { blob, filename } = await encryptFile(file, pwd, opts);
       blobDownloadLink(blob, filename, downloadEnc);
       encResult.style.display = 'block';
       setStatus(encStatus, 'Encryption successful!', 'success');
@@ -214,7 +252,7 @@
 
   // Wire up Decrypt panel
   setupDrop(decDrop, decFileInput, decFileName);
-  decBrowse.addEventListener('click', (e) => { e.preventDefault(); decFileInput.click(); });
+  decBrowse.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); decFileInput.click(); });
   decFileInput.addEventListener('change', () => {
     const f = decFileInput.files?.[0];
     decFileName.textContent = f ? `${f.name} (${(f.size/1024).toFixed(1)} KB)` : 'No file selected';


### PR DESCRIPTION
This PR adds a **File Encryptor & Decryptor** tool.

It performs password-based encryption and decryption using the Web Crypto API (AES-GCM) and supports advanced options like:

- PBKDF2 Iterations
- AES-GCM Key Length (bits)
- GCM IV Length (bytes)

Fixes #211 

## 📸 Screenshot (if applicable)
<img width="1621" height="1040" alt="image" src="https://github.com/user-attachments/assets/5ad95ffa-62a3-4944-84b2-2d7993398fd7" />

<details>
  <summary>Preview as GIF</summary>

  ![encryptor](https://github.com/user-attachments/assets/50f7aa8c-30b3-4d25-b15b-f9233fcbf544)

</details>

## ✅ Checklist
- [X] My code follows the contribution guidelines of this project.
- [X] I have added a card for my new tool in the main `index.html`.
- [X] My changes work perfectly on the live demo.