### PR TITLE
Add GitHub Profile Card tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -447,6 +447,25 @@
             </div>
 
             <div id="tools-grid" class="tools-grid">
+                <a href="tools/github-profile-card/index.html" class="tool-card" data-category="utility">
+                    <div class="tool-icon">
+                        <i class="fas fa-user-circle"></i>
+                    </div>
+                    <div class="tool-content">
+                        <h3 class="tool-title">GitHub Profile Card</h3>
+                        <p class="tool-description">
+                        Generate a stylish, shareable GitHub profile card with avatar, bio, and stats.
+                        </p>
+                        <div class="tool-tags">
+                        <span class="tag">API</span>
+                        <span class="tag">GitHub</span>
+                        </div>
+                    </div>
+                    <div class="tool-arrow">
+                        <i class="fas fa-arrow-right"></i>
+                    </div>
+                </a>
+
                 <!-- Word Counter -->
                 <a href="tools/word-counter/index.html" class="tool-card" data-category="text" data-featured="true">
                     <div class="tool-icon">

--- a/tools/github-profile-card/index.html
+++ b/tools/github-profile-card/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GitHub Profile Card</title>
+  <link rel="stylesheet" href="../../style.css" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="script.js" defer></script>
+</head>
+<body>
+  <a href="../../index.html" class="back-button">← Back To Tools</a>
+
+  <div class="tool-container">
+    <h1>GitHub Profile Card Generator</h1>
+    <p>Enter a GitHub username to view a stylish profile card.</p>
+
+    <div class="input-box">
+      <input type="text" id="username" placeholder="Enter GitHub username..." />
+      <button id="fetch-btn">Generate</button>
+    </div>
+
+    <div id="profile-card" class="card hidden"></div>
+  </div>
+</body>
+</html>

--- a/tools/github-profile-card/script.js
+++ b/tools/github-profile-card/script.js
@@ -1,0 +1,36 @@
+document.getElementById("fetch-btn").addEventListener("click", async () => {
+  const username = document.getElementById("username").value.trim();
+  const card = document.getElementById("profile-card");
+
+  if (!username) {
+    card.innerHTML = "<p>Please enter a username.</p>";
+    card.classList.remove("hidden");
+    return;
+  }
+
+  try {
+    const res = await fetch(`https://api.github.com/users/${username}`);
+    const data = await res.json();
+
+    if (data.message === "Not Found") {
+      card.innerHTML = "<p>User not found. Try again!</p>";
+      card.classList.remove("hidden");
+      return;
+    }
+
+    card.innerHTML = `
+      <img src="${data.avatar_url}" alt="${data.login}" class="avatar"/>
+      <h2>${data.name || data.login}</h2>
+      <p class="bio">${data.bio || "No bio available."}</p>
+      <div class="stats">
+        <span>👥 ${data.followers} Followers</span>
+        <span>📦 ${data.public_repos} Repos</span>
+      </div>
+      <a href="${data.html_url}" target="_blank" class="profile-link">View Profile →</a>
+    `;
+    card.classList.remove("hidden");
+  } catch (error) {
+    card.innerHTML = "<p>Something went wrong. Try again later!</p>";
+    card.classList.remove("hidden");
+  }
+});

--- a/tools/github-profile-card/style.css
+++ b/tools/github-profile-card/style.css
@@ -1,0 +1,256 @@
+/* =========================
+   HACKTOBERFEST DESIGN SYSTEM
+========================= */
+:root {
+  --primary-color: #ff6b35;      /* Hacktoberfest Orange */
+  --secondary-color: #0081b4;    /* Blue */
+  --bg-primary: #0f0f23;         /* Dark Background */
+  --bg-secondary: #1a1a2e;       /* Card Background */
+  --text-primary: #ffffff;       /* White Text */
+  --font-family: 'Poppins', sans-serif;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: var(--font-family);
+}
+
+body {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  text-align: center;
+  min-height: 100vh;
+  overflow: hidden;
+  position: relative;
+}
+
+/* =========================
+   Animated Floating Shapes
+========================= */
+body::before, body::after {
+  content: '';
+  position: absolute;
+  width: 150px;
+  height: 150px;
+  background: radial-gradient(
+    circle at center,
+    var(--secondary-color),
+    transparent 70%
+  );
+  border-radius: 50%;
+  animation: float 8s ease-in-out infinite;
+  opacity: 0.3;
+}
+
+body::after {
+  background: radial-gradient(
+    circle at center,
+    var(--primary-color),
+    transparent 70%
+  );
+  width: 200px;
+  height: 200px;
+  right: 10%;
+  top: 60%;
+  animation-delay: 4s;
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0) rotate(0);
+  }
+  50% {
+    transform: translateY(-20px) rotate(45deg);
+  }
+}
+
+/* =========================
+   Back Button
+========================= */
+.back-button {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  background: var(--bg-secondary);
+  color: var(--primary-color);
+  border-radius: 8px;
+  padding: 8px 14px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: 0.3s ease;
+  box-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
+}
+
+.back-button:hover {
+  background: var(--primary-color);
+  color: var(--text-primary);
+}
+
+/* =========================
+   Tool Layout
+========================= */
+.tool-container {
+  margin-top: 100px;
+  padding: 20px;
+  animation: fadeIn 1s ease;
+}
+
+/* ✨ Main heading and subheading */
+h1 {
+  font-size: 2.8rem;
+  color: var(--primary-color);
+  margin-bottom: 8px;
+  letter-spacing: 0.5px;
+}
+
+p {
+  font-size: 1.1rem;
+  color: #b0b0b0; /* softer grey tone */
+  margin-bottom: 25px;
+}
+
+/* =========================
+   Input + Button
+========================= */
+.input-box {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+input {
+  padding: 14px;
+  border: none;
+  border-radius: 10px;
+  width: 350px; /* Increased width */
+  outline: none;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: 0.3s ease;
+}
+
+input:focus {
+  box-shadow: 0 0 10px var(--secondary-color);
+}
+
+/* 🎃 Orange gradient button */
+button {
+  background: linear-gradient(135deg, #ff6b35, #ff944d);
+  border: none;
+  padding: 14px 25px;
+  border-radius: 10px;
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: 0.3s ease;
+  box-shadow: 0 0 10px rgba(255, 107, 53, 0.4);
+}
+
+button:hover {
+  background: linear-gradient(135deg, #ff944d, #ff6b35);
+  transform: scale(1.05);
+  box-shadow: 0 0 20px rgba(255, 107, 53, 0.6);
+}
+
+/* =========================
+   Profile Card
+========================= */
+.card {
+  background: var(--bg-secondary);
+  border-radius: 16px;
+  max-width: 360px;
+  margin: 30px auto;
+  padding: 25px;
+  box-shadow: 0 0 20px rgba(255, 255, 255, 0.05);
+  transition: 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 0 25px rgba(255, 107, 53, 0.3);
+}
+
+.hidden {
+  display: none;
+}
+
+.avatar {
+  width: 110px;
+  height: 110px;
+  border-radius: 50%;
+  margin-bottom: 15px;
+  border: 3px solid var(--secondary-color);
+  transition: 0.3s ease;
+}
+
+.avatar:hover {
+  transform: scale(1.05);
+}
+
+.bio {
+  font-size: 0.9rem;
+  color: #aaa;
+  margin: 10px 0 15px;
+}
+
+.stats {
+  display: flex;
+  justify-content: space-around;
+  margin: 10px 0;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.profile-link {
+  display: inline-block;
+  margin-top: 10px;
+  color: var(--secondary-color);
+  text-decoration: none;
+  font-weight: bold;
+  transition: color 0.3s;
+}
+
+.profile-link:hover {
+  color: var(--primary-color);
+}
+
+/* =========================
+   Animations & Responsive
+========================= */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 600px) {
+  .card {
+    width: 90%;
+    padding: 15px;
+  }
+
+  input {
+    width: 80%;
+  }
+
+  h1 {
+    font-size: 2.2rem;
+  }
+
+  p {
+    font-size: 1rem;
+  }
+}


### PR DESCRIPTION
## 🛠️ Tool: GitHub Profile Card

### 📝 Description
A tool where users can enter a GitHub username to instantly generate a stylish, shareable profile card featuring their avatar, name, bio, followers, and public repository count.  
Built using the GitHub API with a dark Hacktoberfest-themed UI.

### ✨ Features
- Fetches real-time GitHub user data via API
- Displays avatar, bio, followers, and repository stats
- Responsive and mobile-friendly design
- Animated background and smooth hover transitions
- Orange gradient button and glowing theme for Hacktoberfest 2025

### 📱 Testing
- [x] Desktop (Chrome, Firefox, Safari)
- [x] Mobile responsive design
- [x] All functionality working
- [x] No console errors

### 🎨 Design Compliance
- [x] Uses TOOL_TEMPLATE.md
- [x] Consistent with main website design
- [x] Includes animated background
- [x] Back button implemented
- [x] Mobile responsive

### 📸 Screenshots
<img width="1920" height="917" alt="image" src="https://github.com/user-attachments/assets/74b556fe-5303-49dd-89d6-633a692c426a" />

Closes #255
