### PR TITLE
Add HMAC Hash Generator (SHA-256) tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,6 +506,28 @@
                     </div>
                 </a>
 
+                <!-- HMAC Hash Generator -->
+                <a href="tools/hash-generator/index.html" class="tool-card" data-category="utility">
+                    <div class="tool-icon">
+                        <i class="fas fa-hashtag"></i>
+                    </div>
+                    <div class="tool-content">
+                        <h3 class="tool-title">HMAC Hash Generator</h3>
+                        <p class="tool-description">
+                            Create a Hash-based Message Authentication Code using SHA-256.
+                            Enter your message and secret key to generate the HMAC securely in your browser.
+                        </p>
+                        <div class="tool-tags">
+                            <span class="tag">HMAC</span>
+                            <span class="tag">Hash</span>
+                            <span class="tag">SHA-256</span>
+                        </div>
+                    </div>
+                    <div class="tool-arrow">
+                        <i class="fas fa-arrow-right"></i>
+                    </div>
+                </a>
+
                 <!--Discount Calculator-->
                 <a href="tools/SimpleDiscountCalculator/index.html" class="tool-card" data-category="utility">
                     <div class="tool-icon">

--- a/tools/hash-generator/index.html
+++ b/tools/hash-generator/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HMAC Hash Generator (SHA-256) - DevToolkit</title>
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="./style.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+        rel="stylesheet">
+    <meta name="description" content="Generate HMAC (SHA-256) hashes from a message and secret key in your browser.">
+</head>
+
+<body>
+    <!-- Animated Background -->
+    <div class="animated-bg">
+        <div class="floating-shapes">
+            <div class="shape shape-1"></div>
+            <div class="shape shape-2"></div>
+            <div class="shape shape-3"></div>
+            <div class="shape shape-4"></div>
+            <div class="shape shape-5"></div>
+        </div>
+    </div>
+
+    <!-- Back Button -->
+    <a href="../../index.html" class="back-button">
+        <i class="fas fa-arrow-left"></i>
+        Back to Tools
+    </a>
+
+    <div class="tool-container">
+        <!-- Header -->
+        <div class="tool-header">
+            <h1 class="tool-title">HMAC Hash Generator</h1>
+            <p class="tool-subtitle">
+                Create a Hash-based Message Authentication Code using SHA-256.<br>Enter your message and secret key to generate the HMAC securely in your browser.
+            </p>
+        </div>
+
+        <!-- Input Section -->
+        <div class="hmac-input-section">
+            <div class="hmac-rows">
+                <div class="hmac-group">
+                    <label class="hmac-label"><i class="fas fa-comment-dots"></i> Message</label>
+                    <textarea id="message-input" class="hmac-textarea" rows="4" placeholder="Enter message..."></textarea>
+                </div>
+                <div class="hmac-group">
+                    <label class="hmac-label"><i class="fas fa-key"></i> Secret Key</label>
+                    <input id="secret-input" type="text" class="hmac-input" placeholder="Enter secret key...">
+                </div>
+            </div>
+            <div class="hmac-rows">
+                <div class="hmac-group">
+                    <label class="hmac-label"><i class="fas fa-sliders"></i> Output Format</label>
+                    <div class="hmac-options">
+                        <label class="hmac-option">
+                            <input type="radio" name="output-format" value="hex" checked>
+                            <span>Hex</span>
+                        </label>
+                        <label class="hmac-option">
+                            <input type="radio" name="output-format" value="base64">
+                            <span>Base64</span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Generate Button -->
+        <div class="hmac-convert">
+            <button class="hmac-btn-generate" id="generate-btn">
+                <i class="fas fa-shield-alt"></i>
+                Generate HMAC
+            </button>
+        </div>
+
+        <!-- Output Section -->
+        <div class="hmac-output">
+            <div class="hmac-output-label">
+                <i class="fas fa-fingerprint"></i>
+                HMAC (SHA-256)
+            </div>
+            <div id="hmac-output" class="hmac-result">Enter a message and secret key, then click Generate HMAC.</div>
+            <button class="hmac-btn-copy" id="copy-btn" disabled>
+                <i class="fas fa-copy"></i>
+                Copy Result
+            </button>
+        </div>
+    </div>
+    <script src="script.js"></script>
+</body>
+
+</html>

--- a/tools/hash-generator/script.js
+++ b/tools/hash-generator/script.js
@@ -1,0 +1,114 @@
+document.addEventListener('DOMContentLoaded', function () {
+	const messageInput = document.getElementById('message-input');
+	const secretInput = document.getElementById('secret-input');
+	const generateBtn = document.getElementById('generate-btn');
+	const outputEl = document.getElementById('hmac-output');
+	const copyBtn = document.getElementById('copy-btn');
+
+	function getSelectedFormat() {
+		const checked = document.querySelector('input[name="output-format"]:checked');
+		return checked ? checked.value : 'hex';
+	}
+
+	function toHex(buffer) {
+		const bytes = new Uint8Array(buffer);
+		let hex = '';
+		for (let i = 0; i < bytes.length; i++) {
+			hex += bytes[i].toString(16).padStart(2, '0');
+		}
+		return hex;
+	}
+
+	function toBase64(buffer) {
+		const bytes = new Uint8Array(buffer);
+		let binary = '';
+		for (let i = 0; i < bytes.length; i++) {
+			binary += String.fromCharCode(bytes[i]);
+		}
+		return btoa(binary);
+	}
+
+	async function hmacSHA256(message, key) {
+		const enc = new TextEncoder();
+		const keyData = enc.encode(key);
+		const msgData = enc.encode(message);
+
+		const cryptoKey = await crypto.subtle.importKey(
+			'raw',
+			keyData,
+			{ name: 'HMAC', hash: { name: 'SHA-256' } },
+			false,
+			['sign']
+		);
+
+		return await crypto.subtle.sign('HMAC', cryptoKey, msgData);
+	}
+
+	async function generate() {
+		const message = messageInput.value || '';
+		const secret = secretInput.value || '';
+
+		if (!message.trim() || !secret.trim()) {
+			outputEl.textContent = 'Please enter both message and secret key.';
+			copyBtn.disabled = true;
+			return;
+		}
+
+		try {
+			const signature = await hmacSHA256(message, secret);
+			const format = getSelectedFormat();
+			const value = format === 'base64' ? toBase64(signature) : toHex(signature);
+			outputEl.textContent = value;
+			copyBtn.disabled = false;
+
+			generateBtn.classList.add('clicked');
+			generateBtn.innerHTML = '<i class="fas fa-check"></i> Generated!';
+			setTimeout(() => {
+				generateBtn.classList.remove('clicked');
+				generateBtn.innerHTML = '<i class="fas fa-shield-alt"></i> Generate HMAC';
+			}, 1200);
+		} catch (e) {
+			outputEl.textContent = 'Error generating HMAC in this browser.';
+			copyBtn.disabled = true;
+		}
+	}
+
+	generateBtn.addEventListener('click', generate);
+
+	copyBtn.addEventListener('click', async function () {
+		const text = outputEl.textContent || '';
+		if (!text) return;
+		try {
+			await navigator.clipboard.writeText(text);
+			copyBtn.innerHTML = '<i class="fas fa-check"></i> Copied!';
+			copyBtn.classList.add('copied');
+			copyBtn.style.background = 'var(--success-color)';
+			copyBtn.style.borderColor = 'var(--success-color)';
+			setTimeout(() => {
+				copyBtn.innerHTML = '<i class="fas fa-copy"></i> Copy to Clipboard';
+				copyBtn.classList.remove('copied');
+				copyBtn.style.background = '';
+				copyBtn.style.borderColor = '';
+			}, 1600);
+		} catch (err) {
+			const textArea = document.createElement('textarea');
+			textArea.value = text;
+			document.body.appendChild(textArea);
+			textArea.select();
+			document.execCommand('copy');
+			document.body.removeChild(textArea);
+			copyBtn.innerHTML = '<i class="fas fa-check"></i> Copied!';
+			setTimeout(() => {
+				copyBtn.innerHTML = '<i class="fas fa-copy"></i> Copy to Clipboard';
+			}, 1600);
+		}
+	});
+
+	// Keyboard accessibility for Enter/Space on button
+	generateBtn.addEventListener('keydown', function (e) {
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			generateBtn.click();
+		}
+	});
+});

--- a/tools/hash-generator/style.css
+++ b/tools/hash-generator/style.css
@@ -1,0 +1,173 @@
+.tool-container {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+.tool-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.tool-title {
+    font-size: clamp(2rem, 4vw, 3rem);
+    font-weight: 700;
+    background: var(--gradient-primary);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin-bottom: 1rem;
+}
+
+.tool-subtitle {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.hmac-input-section {
+    background: var(--bg-secondary);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-lg);
+    padding: 2rem;
+    margin-bottom: 2rem;
+    position: relative;
+    overflow: hidden;
+}
+.hmac-input-section::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background: var(--gradient-primary);
+}
+.hmac-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+.hmac-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+.hmac-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+.hmac-label i { color: var(--primary-color); }
+.hmac-textarea,
+.hmac-input {
+    padding: 0.75rem 1rem;
+    background: var(--bg-primary);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-size: 1rem;
+}
+.hmac-textarea:focus,
+.hmac-input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 20px rgba(255, 107, 53, 0.2);
+}
+.hmac-options { display: flex; gap: 1rem; flex-wrap: wrap; }
+.hmac-option { display: flex; align-items: center; gap: 0.5rem; }
+.hmac-convert {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 2rem;
+}
+.hmac-btn-generate {
+    padding: 1rem 3rem;
+    background: var(--gradient-primary);
+    border: none;
+    border-radius: var(--radius-md);
+    color: white;
+    font-size: 1.1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+.hmac-btn-generate:hover { transform: translateY(-3px); box-shadow: 0 10px 30px rgba(255,107,53,0.3); }
+.hmac-btn-generate:active { transform: translateY(-1px); }
+.hmac-output {
+    background: var(--bg-secondary);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-lg);
+    padding: 2rem;
+    position: relative;
+    overflow: hidden;
+}
+.hmac-output::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; width: 100%; height: 2px;
+    background: var(--gradient-primary);
+}
+.hmac-output-label {
+    display: flex; align-items: center; gap: 0.5rem;
+    font-size: 1.1rem; font-weight: 600; color: var(--text-primary);
+    margin-bottom: 1rem;
+}
+.hmac-result {
+    background: rgba(255, 107, 53, 0.05);
+    padding: 1.5rem;
+    border-radius: var(--radius-md);
+    font-family: 'Courier New', monospace;
+    font-size: 1rem;
+    color: var(--text-primary);
+    min-height: 80px;
+    line-height: 1.6;
+    white-space: pre-wrap;
+}
+.hmac-btn-copy {
+    margin-top: 1rem;
+    padding: 0.5rem 1rem;
+    background: var(--bg-primary);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: flex; align-items: center; gap: 0.5rem;
+}
+.hmac-btn-copy:hover { background: var(--primary-color); color: white; border-color: var(--primary-color); }
+.hmac-btn-copy.copied { background: #00d084; color: white; border-color: #00d084; }
+
+
+.back-button {
+    position: fixed;
+    top: 2rem;
+    left: 2rem;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    text-decoration: none;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    transition: all 0.3s ease;
+    backdrop-filter: blur(20px);
+}
+
+.back-button:hover {
+    background: var(--primary-color);
+    color: white;
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+}


### PR DESCRIPTION
## Enhancement : HMAC Hash Generator (SHA-256) #213
**Description**
This tool enables users to generate a Hash-based Message Authentication Code (HMAC) using the SHA-256 algorithm.
It provides a sleek, user-friendly interface consistent with the DevToolkit design system, allowing secure, client-side hash generation without sending data to any server.
The UI includes fields for entering a message and a secret key, and produces the corresponding HMAC hash instantly within the browser.
All cryptographic operations are handled locally using the Web Crypto API for security and performance.

Fixes #213

**Functionality:**
Accepts message and secret key inputs.
Generates HMAC (SHA-256) and Base64 hash on button click.
Allows easy copy of the generated hash.
Fully client-side and secure.
Styled with DevToolkit’s modern, gradient-based UI.

## Screenshot
<img width="1744" height="714" alt="Screenshot 2025-10-10 202408" src="https://github.com/user-attachments/assets/99eecb59-8585-411e-b6f7-c4fa5ef5621e" />
<img width="1896" height="858" alt="Screenshot 2025-10-10 201011" src="https://github.com/user-attachments/assets/93138215-96a4-426d-8e4b-6f4cf623830c" />

## Checklist
- My code follows the contribution guidelines of this project.
- I have added a card for my new tool in the main `index.html`.
- My changes work perfectly on the live demo.